### PR TITLE
Add default.nix to allow installing Bignums as a Nix package for Coq v8.8.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,9 @@
+{ pkgs ? import <nixpkgs> {},
+  coq ? import (fetchTarball "https://github.com/coq/coq/tarball/v8.8") {} }:
+
+pkgs.stdenv.mkDerivation rec {
+  name = "bignums";
+  src = ./.;
+  buildInputs = with coq.ocamlPackages; [ coq ocaml findlib camlp5_strict ];
+  installFlags = "COQLIB=$(out)/lib/coq/";
+}


### PR DESCRIPTION
Same thing as the first commit of #8 for v8.8.