### PR TITLE
Avoid binding several types at once to the same scope, preparing Coq to PR #7762

### DIFF
--- a/BigN/BigN.v
+++ b/BigN/BigN.v
@@ -41,7 +41,9 @@ Module BigN <: NType <: OrderedTypeFull <: TotalOrder :=
 Local Open Scope bigN_scope.
 
 Notation bigN := BigN.t.
-Bind Scope bigN_scope with bigN BigN.t BigN.t'.
+Bind Scope bigN_scope with bigN.
+Bind Scope bigN_scope with BigN.t.
+Bind Scope bigN_scope with BigN.t'.
 Arguments BigN.N0 _%int31.
 Local Notation "0" := BigN.zero : bigN_scope. (* temporary notation *)
 Local Notation "1" := BigN.one : bigN_scope. (* temporary notation *)

--- a/BigQ/BigQ.v
+++ b/BigQ/BigQ.v
@@ -49,7 +49,9 @@ End BigQ.
 Local Open Scope bigQ_scope.
 
 Notation bigQ := BigQ.t.
-Bind Scope bigQ_scope with bigQ BigQ.t BigQ.t_.
+Bind Scope bigQ_scope with bigQ.
+Bind Scope bigQ_scope with BigQ.t.
+Bind Scope bigQ_scope with BigQ.t_.
 (** As in QArith, we use [#] to denote fractions *)
 Notation "p # q" := (BigQ.Qq p q) (at level 55, no associativity) : bigQ_scope.
 Local Notation "0" := BigQ.zero : bigQ_scope.

--- a/BigZ/BigZ.v
+++ b/BigZ/BigZ.v
@@ -41,7 +41,9 @@ Module BigZ <: ZType <: OrderedTypeFull <: TotalOrder :=
 Local Open Scope bigZ_scope.
 
 Notation bigZ := BigZ.t.
-Bind Scope bigZ_scope with bigZ BigZ.t BigZ.t_.
+Bind Scope bigZ_scope with bigZ.
+Bind Scope bigZ_scope with BigZ.t.
+Bind Scope bigZ_scope with BigZ.t_.
 Arguments BigZ.Pos _%bigN.
 Arguments BigZ.Neg _%bigN.
 Local Notation "0" := BigZ.zero : bigZ_scope.


### PR DESCRIPTION
Motivation for coq/coq#7762:

- On one side, this is undocumented syntax
- On another side, this is misleading as shown in Coq issue #7699. 
- On a third side, the case of several types binding to the same scope looks unusual.
- Finally, this may leave a syntax open for a generalization to `Bind Scope foo with type_pattern` rather than having to add parentheses as in `Bind Scope foo with (type_pattern) ... (type_pattern)`.