### PR TITLE
Revert "chore: Workaround coq/bignums#26"

### DIFF
--- a/coq-bignums.opam
+++ b/coq-bignums.opam
@@ -13,12 +13,12 @@ Provides BigN, BigZ, BigQ that used to be part of Coq standard library
 
 version: "dev"
 
-build: [make "-j%{jobs}%"]
-install: [make "install"]
+build: ["dune" "build" "-p" name "-j" jobs]
 
 depends: [
   "ocaml"
   "coq" {= "dev"}
+  "dune" {>= "1.9.0"}
 ]
 
 tags: [


### PR DESCRIPTION
This reverts commit 38460256dcfae0da7d6f2514e0f7cbfeb748474b.

Backport from `master`.