### PR TITLE
[omega] Remove use of undocumented from `omega with *`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ Makefile.coq
 Makefile.coq.conf
 .merlin
 *.install
+*.vos
+*.vok

--- a/BigN/NMake.v
+++ b/BigN/NMake.v
@@ -1356,7 +1356,7 @@ Module Make (W0:CyclicType) <: NType.
  intros n x p K HK Hx Hp. simpl. rewrite spec_reduce.
  destruct (ZnZ.spec_to_Z x).
  destruct (ZnZ.spec_to_Z p).
- rewrite ZnZ.spec_add_mul_div by (omega with *).
+ rewrite ZnZ.spec_add_mul_div by (zify; omega).
  rewrite ZnZ.spec_0, Zdiv_0_l, Z.add_0_r.
  apply Zmod_small. unfold base.
  split; auto with zarith.

--- a/BigN/gen/NMake_gen.ml
+++ b/BigN/gen/NMake_gen.ml
@@ -722,7 +722,7 @@ pr
  set (f' := fun n x y => (n, f n x y)).
  set (P' := fun z z' r => P (fst r) z z' (snd r)).
  assert (FST : forall x y, level x <= fst (same_level f' x y))
-  by (destruct x, y; simpl; omega with * ).
+  by (destruct x, y; simpl; zify; omega).
  assert (SND : forall x y, same_level f x y = snd (same_level f' x y))
   by (destruct x, y; reflexivity).
  intros. eapply Pantimon; [eapply FST|].

--- a/BigZ/ZMake.v
+++ b/BigZ/ZMake.v
@@ -232,7 +232,7 @@ Module Make (NN:NType) <: ZType.
  unfold add, to_Z; intros [x | x] [y | y];
    try (rewrite NN.spec_add; auto with zarith);
  rewrite NN.spec_compare; case Z.compare_spec;
-  unfold zero; rewrite ?NN.spec_0, ?NN.spec_sub; omega with *.
+  unfold zero; rewrite ?NN.spec_0, ?NN.spec_sub; zify; omega.
  Qed.
 
  Definition pred x :=
@@ -251,7 +251,7 @@ Module Make (NN:NType) <: ZType.
    try (rewrite NN.spec_succ; ring).
  rewrite NN.spec_compare; case Z.compare_spec;
   rewrite ?NN.spec_0, ?NN.spec_1, ?NN.spec_pred;
-  generalize (NN.spec_pos x); omega with *.
+  generalize (NN.spec_pos x); zify; omega.
  Qed.
 
  Definition sub x y :=
@@ -277,7 +277,7 @@ Module Make (NN:NType) <: ZType.
  unfold sub, to_Z; intros [x | x] [y | y];
   try (rewrite NN.spec_add; auto with zarith);
  rewrite NN.spec_compare; case Z.compare_spec;
-  unfold zero; rewrite ?NN.spec_0, ?NN.spec_sub; omega with *.
+  unfold zero; rewrite ?NN.spec_0, ?NN.spec_sub; zify; omega.
  Qed.
 
  Definition mul x y :=
@@ -438,7 +438,7 @@ Module Make (NN:NType) <: ZType.
  break_nonneg r pr EQr.
  subst; simpl. rewrite NN.spec_0; auto.
  subst. lazy iota beta delta [Z.eqb].
- rewrite NN.spec_sub, NN.spec_succ, EQy, EQr. f_equal. omega with *.
+ rewrite NN.spec_sub, NN.spec_succ, EQy, EQr. f_equal. zify; omega.
  (* Neg Pos *)
  generalize (NN.spec_div_eucl x y); destruct (NN.div_eucl x y) as (q,r).
  break_nonneg x px EQx; break_nonneg y py EQy;
@@ -453,7 +453,7 @@ Module Make (NN:NType) <: ZType.
  break_nonneg r pr EQr.
  subst; simpl. rewrite NN.spec_0; auto.
  subst. lazy iota beta delta [Z.eqb].
- rewrite NN.spec_sub, NN.spec_succ, EQy, EQr. f_equal. omega with *.
+ rewrite NN.spec_sub, NN.spec_succ, EQy, EQr. f_equal. zify; omega.
  (* Neg Neg *)
  generalize (NN.spec_div_eucl x y); destruct (NN.div_eucl x y) as (q,r).
  break_nonneg x px EQx; break_nonneg y py EQy;

--- a/SpecViaZ/NSigNAxioms.v
+++ b/SpecViaZ/NSigNAxioms.v
@@ -6,7 +6,7 @@
 (*         *       GNU Lesser General Public License Version 2.1        *)
 (************************************************************************)
 
-Require Import ZArith OrdersFacts Nnat NAxioms NSig.
+Require Import ZArith OrdersFacts Nnat NAxioms NSig Lia.
 
 (** * The interface [NSig.NType] implies the interface [NAxiomsSig] *)
 
@@ -22,7 +22,7 @@ Hint Rewrite
 Ltac nsimpl := autorewrite with nsimpl.
 Ltac ncongruence := unfold eq, to_N; repeat red; intros; nsimpl; congruence.
 Ltac zify := unfold eq, lt, le, to_N in *; nsimpl.
-Ltac omega_pos n := generalize (spec_pos n); omega with *.
+Ltac omega_pos n := generalize (spec_pos n); lia.
 
 Local Obligation Tactic := ncongruence.
 
@@ -112,7 +112,7 @@ Qed.
 
 Theorem sub_succ_r : forall n m, n - (succ m) == pred (n - m).
 Proof.
-intros. zify. omega with *.
+intros. zify. lia.
 Qed.
 
 Theorem mul_0_l : forall n, 0 * n == 0.
@@ -196,22 +196,22 @@ Qed.
 
 Theorem min_l : forall n m, n <= m -> min n m == n.
 Proof.
-intros n m. zify. omega with *.
+now intros n m; zify; lia.
 Qed.
 
 Theorem min_r : forall n m, m <= n -> min n m == m.
 Proof.
-intros n m. zify. omega with *.
+now intros n m; zify; lia.
 Qed.
 
 Theorem max_l : forall n m, m <= n -> max n m == n.
 Proof.
-intros n m. zify. omega with *.
+now intros n m; zify; lia.
 Qed.
 
 Theorem max_r : forall n m, n <= m -> max n m == m.
 Proof.
-intros n m. zify. omega with *.
+now intros n m; zify; lia.
 Qed.
 
 (** Properties specific to natural numbers, not integers. *)

--- a/SpecViaZ/ZSigZAxioms.v
+++ b/SpecViaZ/ZSigZAxioms.v
@@ -6,7 +6,7 @@
 (*         *       GNU Lesser General Public License Version 2.1        *)
 (************************************************************************)
 
-Require Import Bool ZArith OrdersFacts Nnat ZAxioms ZSig.
+Require Import Bool ZArith OrdersFacts Nnat ZAxioms ZSig Lia.
 
 (** * The interface [ZSig.ZType] implies the interface [ZAxiomsSig] *)
 
@@ -207,22 +207,22 @@ Qed.
 
 Theorem min_l : forall n m, n <= m -> min n m == n.
 Proof.
-intros n m. zify. omega with *.
+now intros n m; zify; lia.
 Qed.
 
 Theorem min_r : forall n m, m <= n -> min n m == m.
 Proof.
-intros n m. zify. omega with *.
+now intros n m; zify; lia.
 Qed.
 
 Theorem max_l : forall n m, m <= n -> max n m == n.
 Proof.
-intros n m. zify. omega with *.
+now intros n m; zify; lia.
 Qed.
 
 Theorem max_r : forall n m, n <= m -> max n m == m.
 Proof.
-intros n m. zify. omega with *.
+now intros n m; zify; lia.
 Qed.
 
 (** Part specific to integers, not natural numbers *)
@@ -250,27 +250,27 @@ Qed.
 
 Theorem abs_eq : forall n, 0 <= n -> abs n == n.
 Proof.
-intros n. zify. omega with *.
+now intros n; zify; lia.
 Qed.
 
 Theorem abs_neq : forall n, n <= 0 -> abs n == -n.
 Proof.
-intros n. zify. omega with *.
+now intros n; zify; lia.
 Qed.
 
 Theorem sgn_null : forall n, n==0 -> sgn n == 0.
 Proof.
-intros n. zify. omega with *.
+now intros n; zify; lia.
 Qed.
 
 Theorem sgn_pos : forall n, 0<n -> sgn n == 1.
 Proof.
-intros n. zify. omega with *.
+now intros n; zify; lia.
 Qed.
 
 Theorem sgn_neg : forall n, n<0 -> sgn n == opp 1.
 Proof.
-intros n. zify. omega with *.
+now intros n; zify; lia.
 Qed.
 
 (** Power *)


### PR DESCRIPTION
This is to help https://github.com/coq/coq/pull/11288 , in most cases
we just change `omega with *` to `zify; omega`. In a few cases we had
to call `lia`, but this should be cleaned up when upstream merges a
few more micromega / omega PRs.

Performance impact should be minimal.