### PR TITLE
Prepare the release of coq-bignums.8.11.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ Makefile.coq
 Makefile.coq.conf
 .merlin
 *.install
+*.vos
+*.vok

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,6 @@ matrix:
     - NJOBS=2
     <<: *OPAM
 
-  # Note: to be removed in due time
   - env:
     - COQ_IMAGE=coqorg/coq:8.11
     - CONTRIB_NAME=coq-bignums

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,3 +50,9 @@ matrix:
     - NJOBS=2
     <<: *OPAM
 
+  # Note: to be removed in due time
+  - env:
+    - COQ_IMAGE=coqorg/coq:8.11
+    - CONTRIB_NAME=coq-bignums
+    - NJOBS=2
+    <<: *OPAM

--- a/BigN/NMake.v
+++ b/BigN/NMake.v
@@ -789,12 +789,12 @@ Module Make (W0:CyclicType) <: NType.
  Proof.
  intros x n; generalize x; elim n; clear n x; simpl pow_pos.
  intros; rewrite spec_mul; rewrite spec_square; rewrite H.
- rewrite Pos2Z.inj_xI; rewrite Zpower_exp; auto with zarith.
- rewrite (Z.mul_comm 2); rewrite Z.pow_mul_r; auto with zarith.
+ rewrite Pos2Z.inj_xI; rewrite Zpower_exp by auto with zarith.
+ rewrite (Z.mul_comm 2); rewrite Z.pow_mul_r by auto with zarith.
  rewrite Z.pow_2_r; rewrite Z.pow_1_r; auto.
  intros; rewrite spec_square; rewrite H.
  rewrite Pos2Z.inj_xO; auto with zarith.
- rewrite (Z.mul_comm 2); rewrite Z.pow_mul_r; auto with zarith.
+ rewrite (Z.mul_comm 2); rewrite Z.pow_mul_r by auto with zarith.
  rewrite Z.pow_2_r; auto.
  intros; rewrite Z.pow_1_r; auto.
  Qed.
@@ -1281,9 +1281,9 @@ Module Make (W0:CyclicType) <: NType.
  Proof.
    intros x y z HH HH1 HH2.
    split; auto with zarith.
-   apply Z.le_lt_trans with (2 := HH2); auto with zarith.
-   apply Zdiv_le_upper_bound; auto with zarith.
-   pattern x at 1; replace x with (x * 2 ^ 0); auto with zarith.
+   apply Z.le_lt_trans with (2 := HH2).
+   apply Zdiv_le_upper_bound. auto with zarith.
+   pattern x at 1; replace x with (x * 2 ^ 0).
    apply Z.mul_le_mono_nonneg_l; auto.
    apply Z.pow_le_mono_r; auto with zarith.
    rewrite Z.pow_0_r; ring.
@@ -1356,7 +1356,7 @@ Module Make (W0:CyclicType) <: NType.
  intros n x p K HK Hx Hp. simpl. rewrite spec_reduce.
  destruct (ZnZ.spec_to_Z x).
  destruct (ZnZ.spec_to_Z p).
- rewrite ZnZ.spec_add_mul_div by (omega with *).
+ rewrite ZnZ.spec_add_mul_div by (zify; omega).
  rewrite ZnZ.spec_0, Zdiv_0_l, Z.add_0_r.
  apply Zmod_small. unfold base.
  split; auto with zarith.
@@ -1373,7 +1373,7 @@ Module Make (W0:CyclicType) <: NType.
  intros.
  destruct (Z.eq_dec [x] 0) as [EQ|NEQ].
  (* [x] = 0 *)
- apply spec_unsafe_shiftl_aux with 0; auto with zarith.
+ apply spec_unsafe_shiftl_aux with 0. auto with zarith.
  now rewrite EQ.
  rewrite spec_head00 in *; auto with zarith.
  (* [x] <> 0 *)
@@ -1408,7 +1408,7 @@ Module Make (W0:CyclicType) <: NType.
  Proof.
  intros x. rewrite ! digits_level, double_size_level.
  rewrite 2 digits_dom_op, 2 Pshiftl_nat_Zpower,
-         Nat2Z.inj_succ, Z.pow_succ_r; auto with zarith.
+         Nat2Z.inj_succ, Z.pow_succ_r by auto with zarith.
  ring.
  Qed.
 
@@ -1443,7 +1443,7 @@ Module Make (W0:CyclicType) <: NType.
      rewrite <- (fun x y z => Z.pow_add_r x (y - z)); auto with zarith.
      rewrite Z.sub_add.
      apply Z.le_trans with (2 := Z.lt_le_incl _ _ HH2).
-     apply Z.mul_le_mono_nonneg_l; auto with zarith.
+     apply Z.mul_le_mono_nonneg_l. auto with zarith.
      rewrite Z.pow_1_r; auto with zarith.
    - apply Z.pow_le_mono_r; auto with zarith.
      case (Z.le_gt_cases (Zpos (digits x)) [head0 x]); auto with zarith; intros HH6.
@@ -1484,7 +1484,7 @@ Module Make (W0:CyclicType) <: NType.
  generalize F3; rewrite <- (spec_double_size x); intros F4.
  absurd (2 ^ (Zpos (xO (digits x)) - 1) < 2 ^ (Zpos (digits x))).
  { apply Z.le_ngt.
-   apply Z.pow_le_mono_r; auto with zarith.
+   apply Z.pow_le_mono_r. auto with zarith.
    rewrite Pos2Z.inj_xO; auto with zarith. }
  case (spec_head0 x F3).
  rewrite <- F1; rewrite Z.pow_0_r; rewrite Z.mul_1_l; intros _ HH.

--- a/BigN/Nbasic.v
+++ b/BigN/Nbasic.v
@@ -338,7 +338,7 @@ Section CompareRec.
   symmetry. apply Z.gt_lt, Z.lt_gt. (* ;-) *)
   assert (0 < wB).
    unfold wB, DoubleBase.double_wB, base; auto with zarith.
-  change 0 with (0 + 0); apply Z.add_lt_le_mono; auto with zarith.
+  change 0 with (0 + 0); apply Z.add_lt_le_mono. 2: auto with zarith.
   apply Z.mul_pos_pos; auto with zarith.
   case (double_to_Z_pos n xl); auto with zarith.
   case (double_to_Z_pos n xh); intros; exfalso; omega.

--- a/BigN/gen/NMake_gen.ml
+++ b/BigN/gen/NMake_gen.ml
@@ -722,7 +722,7 @@ pr
  set (f' := fun n x y => (n, f n x y)).
  set (P' := fun z z' r => P (fst r) z z' (snd r)).
  assert (FST : forall x y, level x <= fst (same_level f' x y))
-  by (destruct x, y; simpl; omega with * ).
+  by (destruct x, y; simpl; zify; omega).
  assert (SND : forall x y, same_level f x y = snd (same_level f' x y))
   by (destruct x, y; reflexivity).
  intros. eapply Pantimon; [eapply FST|].

--- a/BigNumPrelude.v
+++ b/BigNumPrelude.v
@@ -19,6 +19,7 @@ Require Export ZArith.
 Require Export Znumtheory.
 Require Export Zpow_facts.
 Require Int63.
+Require Import Lia.
 
 Declare Scope bigN_scope.
 Declare Scope bigZ_scope.
@@ -73,40 +74,21 @@ Hint Resolve Z.lt_gt Z.le_ge Z_div_pos: zarith.
        a * beta + b <= c * beta + d ->
        0 <= b < beta -> 0 <= d < beta ->
        a <= c.
- Proof.
-  intros a b c d beta H1 (H3, H4) (H5, H6).
-  assert (a - c < 1); auto with zarith.
-  apply Z.mul_lt_mono_pos_r with beta; auto with zarith.
-  apply Z.le_lt_trans with (d  - b); auto with zarith.
-  rewrite Z.mul_sub_distr_r; auto with zarith.
- Qed.
+ Proof. nia. Qed.
 
  Theorem beta_lex_inv: forall a b c d beta,
       a < c -> 0 <= b < beta ->
       0 <= d < beta ->
       a * beta + b < c * beta  + d.
- Proof.
-  intros a b c d beta H1 (H3, H4) (H5, H6).
-  case (Z.le_gt_cases (c * beta + d) (a * beta + b)); auto with zarith.
-  intros H7. contradict H1. apply Z.le_ngt. apply beta_lex with (1 := H7); auto.
- Qed.
+ Proof. nia. Qed.
 
  Lemma beta_mult : forall h l beta,
    0 <= h < beta -> 0 <= l < beta -> 0 <= h*beta+l < beta^2.
- Proof.
-  intros h l beta H1 H2;split. auto with zarith.
-  rewrite <- (Z.add_0_r (beta^2)); rewrite Z.pow_2_r;
-   apply beta_lex_inv;auto with zarith.
- Qed.
+ Proof. nia. Qed.
 
  Lemma Zmult_lt_b :
    forall b x y, 0 <= x < b -> 0 <= y < b -> 0 <= x * y <= b^2 - 2*b + 1.
- Proof.
-  intros b x y (Hx1,Hx2) (Hy1,Hy2);split;auto with zarith.
-  apply Z.le_trans with ((b-1)*(b-1)).
-  apply Z.mul_le_mono_nonneg;auto with zarith.
-  apply Z.eq_le_incl; ring.
- Qed.
+ Proof. nia. Qed.
 
  Lemma sum_mul_carry : forall xh xl yh yl wc cc beta,
    1 < beta ->
@@ -118,41 +100,21 @@ Hint Resolve Z.lt_gt Z.le_ge Z_div_pos: zarith.
    0 <= cc < beta^2 ->
    wc*beta^2 + cc = xh*yl + xl*yh ->
    0 <= wc <= 1.
- Proof.
-  intros xh xl yh yl wc cc beta U H1 H2 H3 H4 H5 H6 H7.
-  assert (H8 := Zmult_lt_b beta xh yl H2 H5).
-  assert (H9 := Zmult_lt_b beta xl yh H3 H4).
-  split;auto with zarith.
-  apply beta_lex with (cc) (beta^2 - 2) (beta^2); auto with zarith.
- Qed.
+ Proof. nia. Qed.
 
  Theorem mult_add_ineq: forall x y cross beta,
    0 <= x < beta ->
    0 <= y < beta ->
    0 <= cross < beta ->
    0 <= x * y + cross < beta^2.
- Proof.
-  intros x y cross beta HH HH1 HH2.
-  split; auto with zarith.
-  apply Z.le_lt_trans with  ((beta-1)*(beta-1)+(beta-1)); auto with zarith.
-  apply Z.add_le_mono; auto with zarith.
-  apply Z.mul_le_mono_nonneg; auto with zarith.
-  rewrite ?Z.mul_sub_distr_l, ?Z.mul_sub_distr_r, Z.pow_2_r; auto with zarith.
- Qed.
+ Proof. nia. Qed.
 
  Theorem mult_add_ineq2: forall x y c cross beta,
    0 <= x < beta ->
    0 <= y < beta ->
    0 <= c*beta + cross <= 2*beta - 2 ->
    0 <= x * y + (c*beta + cross) < beta^2.
- Proof.
-  intros x y c cross beta HH HH1 HH2.
-  split; auto with zarith.
-  apply Z.le_lt_trans with ((beta-1)*(beta-1)+(2*beta-2));auto with zarith.
-  apply Z.add_le_mono; auto with zarith.
-  apply Z.mul_le_mono_nonneg; auto with zarith.
-  rewrite ?Z.mul_sub_distr_l, ?Z.mul_sub_distr_r, Z.pow_2_r; auto with zarith.
- Qed.
+ Proof. nia. Qed.
 
 Theorem mult_add_ineq3: forall x y c cross beta,
    0 <= x < beta ->
@@ -160,12 +122,7 @@ Theorem mult_add_ineq3: forall x y c cross beta,
    0 <= cross <= beta - 2 ->
    0 <= c <= 1 ->
    0 <= x * y + (c*beta + cross) < beta^2.
- Proof.
-  intros x y c cross beta HH HH1 HH2 HH3.
-  apply mult_add_ineq2;auto with zarith.
-  split;auto with zarith.
-  apply Z.le_trans with (1*beta+cross);auto with zarith.
- Qed.
+ Proof. nia. Qed.
 
 Hint Rewrite Z.mul_1_r Z.mul_0_r Z.mul_1_l Z.mul_0_l Z.add_0_l Z.add_0_r Z.sub_0_r: rm10.
 

--- a/BigQ/QMake.v
+++ b/BigQ/QMake.v
@@ -310,11 +310,10 @@ Module Make (NN:NType)(ZZ:ZType)(Import NZ:NType_ZType NN ZZ) <: QType.
 
  Theorem spec_add : forall x y, [add x y] == [x] + [y].
  Proof.
- intros [x | nx dx] [y | ny dy]; unfold Qplus; qsimpl;
-  auto with zarith.
+ intros [x | nx dx] [y | ny dy]; unfold Qplus; qsimpl.
+ 1-2, 4, 6: lia.
  rewrite Pos.mul_1_r, Z2Pos.id; auto.
  rewrite Pos.mul_1_r, Z2Pos.id; auto.
- rewrite Z.mul_eq_0 in *; intuition.
  rewrite Pos2Z.inj_mul, 2 Z2Pos.id; auto.
  Qed.
 

--- a/BigZ/ZMake.v
+++ b/BigZ/ZMake.v
@@ -232,7 +232,7 @@ Module Make (NN:NType) <: ZType.
  unfold add, to_Z; intros [x | x] [y | y];
    try (rewrite NN.spec_add; auto with zarith);
  rewrite NN.spec_compare; case Z.compare_spec;
-  unfold zero; rewrite ?NN.spec_0, ?NN.spec_sub; omega with *.
+  unfold zero; rewrite ?NN.spec_0, ?NN.spec_sub; zify; omega.
  Qed.
 
  Definition pred x :=
@@ -251,7 +251,7 @@ Module Make (NN:NType) <: ZType.
    try (rewrite NN.spec_succ; ring).
  rewrite NN.spec_compare; case Z.compare_spec;
   rewrite ?NN.spec_0, ?NN.spec_1, ?NN.spec_pred;
-  generalize (NN.spec_pos x); omega with *.
+  generalize (NN.spec_pos x); zify; omega.
  Qed.
 
  Definition sub x y :=
@@ -277,7 +277,7 @@ Module Make (NN:NType) <: ZType.
  unfold sub, to_Z; intros [x | x] [y | y];
   try (rewrite NN.spec_add; auto with zarith);
  rewrite NN.spec_compare; case Z.compare_spec;
-  unfold zero; rewrite ?NN.spec_0, ?NN.spec_sub; omega with *.
+  unfold zero; rewrite ?NN.spec_0, ?NN.spec_sub; zify; omega.
  Qed.
 
  Definition mul x y :=
@@ -438,7 +438,7 @@ Module Make (NN:NType) <: ZType.
  break_nonneg r pr EQr.
  subst; simpl. rewrite NN.spec_0; auto.
  subst. lazy iota beta delta [Z.eqb].
- rewrite NN.spec_sub, NN.spec_succ, EQy, EQr. f_equal. omega with *.
+ rewrite NN.spec_sub, NN.spec_succ, EQy, EQr. f_equal. zify; omega.
  (* Neg Pos *)
  generalize (NN.spec_div_eucl x y); destruct (NN.div_eucl x y) as (q,r).
  break_nonneg x px EQx; break_nonneg y py EQy;
@@ -453,7 +453,7 @@ Module Make (NN:NType) <: ZType.
  break_nonneg r pr EQr.
  subst; simpl. rewrite NN.spec_0; auto.
  subst. lazy iota beta delta [Z.eqb].
- rewrite NN.spec_sub, NN.spec_succ, EQy, EQr. f_equal. omega with *.
+ rewrite NN.spec_sub, NN.spec_succ, EQy, EQr. f_equal. zify; omega.
  (* Neg Neg *)
  generalize (NN.spec_div_eucl x y); destruct (NN.div_eucl x y) as (q,r).
  break_nonneg x px EQx; break_nonneg y py EQy;

--- a/CyclicDouble/DoubleBase.v
+++ b/CyclicDouble/DoubleBase.v
@@ -208,11 +208,10 @@ Section DoubleBase.
    clear spec_w_0 w_0 spec_w_1 w_1 spec_w_Bm1 w_Bm1 spec_w_WW spec_w_0W
     spec_to_Z;unfold base.
    assert (2 ^ Zpos w_digits = 2 * (2 ^ (Zpos w_digits - 1))).
-   pattern 2 at 2; rewrite <- Z.pow_1_r.
-   rewrite <- Zpower_exp; auto with zarith.
-   f_equal; auto with zarith.
-   case w_digits; compute; intros; discriminate.
-   rewrite H; f_equal; auto with zarith.
+   { pattern 2 at 2; rewrite <- Z.pow_1_r.
+     rewrite <- Zpower_exp by Lia.lia.
+     f_equal; auto with zarith. }
+   rewrite H; f_equal.
    rewrite Z.mul_comm; apply Z_div_mult; auto with zarith.
   Qed.
 

--- a/CyclicDouble/DoubleCyclic.v
+++ b/CyclicDouble/DoubleCyclic.v
@@ -277,11 +277,11 @@ Section Z_2nZ.
 
  Let gcd_gt :=
   Eval lazy beta delta [ww_gcd_gt] in
-  ww_gcd_gt w_0 w_eq0 w_gcd_gt _ww_digits gcd_gt_fix gcd_cont.
+  ww_gcd_gt w_0 w_eq0 w_gcd_gt gcd_gt_fix gcd_cont _ww_digits.
 
  Let gcd :=
   Eval lazy beta delta [ww_gcd] in
-  ww_gcd compare w_0 w_eq0 w_gcd_gt _ww_digits gcd_gt_fix gcd_cont.
+  ww_gcd compare w_0 w_eq0 w_gcd_gt gcd_gt_fix gcd_cont _ww_digits.
 
  Definition lor (x y : zn2z t) :=
   match x, y with
@@ -635,7 +635,7 @@ Section Z_2nZ.
  Proof.
  refine (spec_ww_head00 w_0 w_0W
                 w_compare w_head0 w_add2 w_zdigits _ww_zdigits
-                w_to_Z _ _ _ (eq_refl _ww_digits) _ _ _ _); wwauto.
+                w_to_Z _ _ _ _ _ _ _ _ ); wwauto.
  exact ZnZ.spec_head00.
  exact ZnZ.spec_zdigits.
  Qed.
@@ -653,7 +653,7 @@ Section Z_2nZ.
  Proof.
  refine (spec_ww_tail00 w_0 w_0W
                 w_compare w_tail0 w_add2 w_zdigits _ww_zdigits
-                w_to_Z _ _ _ (eq_refl _ww_digits) _ _ _ _); wwauto.
+                w_to_Z _ _ _ _ _ _ _ _); wwauto.
  exact ZnZ.spec_tail00.
  exact ZnZ.spec_zdigits.
  Qed.
@@ -738,15 +738,15 @@ refine
 
  Let spec_ww_mod :  forall a b, 0 < [|b|] -> [|mod_ a b|] = [|a|] mod [|b|].
  Proof.
-  refine (spec_ww_mod w_digits W0 compare mod_gt w_to_Z _ _ _);wwauto.
+  refine (spec_ww_mod w_digits compare mod_gt w_to_Z _ _ _);wwauto.
  Qed.
 
  Let spec_ww_gcd_gt : forall a b, [|a|] > [|b|] ->
       Zis_gcd [|a|] [|b|] [|gcd_gt a b|].
  Proof.
-  refine (@spec_ww_gcd_gt t w_digits W0 w_to_Z _
-    w_0 w_0 w_eq0 w_gcd_gt _ww_digits
-  _ gcd_gt_fix _ _ _ _ gcd_cont _);wwauto.
+  refine (@spec_ww_gcd_gt t w_digits w_to_Z _
+    w_0 w_eq0 w_gcd_gt
+  gcd_gt_fix _ _ _ _ gcd_cont _ _ww_digits _);wwauto.
   refine (@spec_ww_gcd_gt_aux t w_digits w_0 w_WW w_0W w_compare w_opp_c w_opp
    w_opp_carry w_sub_c w_sub w_sub_carry w_gcd_gt w_add_mul_div w_head0
    w_div21 div32 _ww_zdigits ww_1 add_mul_div w_zdigits w_to_Z
@@ -754,14 +754,14 @@ refine
   exact ZnZ.spec_div21.
   exact ZnZ.spec_zdigits.
   exact spec_ww_add_mul_div.
-  refine (@spec_gcd_cont t w_digits ww_1 w_to_Z _ _ w_0 w_1 w_compare
+  refine (@spec_gcd_cont t w_digits ww_1 w_to_Z _ _ w_1 w_compare
    _ _);wwauto.
  Qed.
 
  Let spec_ww_gcd : forall a b, Zis_gcd [|a|] [|b|] [|gcd a b|].
  Proof.
-  refine (@spec_ww_gcd t w_digits W0 compare w_to_Z _ _ w_0 w_0 w_eq0 w_gcd_gt
-  _ww_digits _ gcd_gt_fix _ _ _ _ gcd_cont _);wwauto.
+  refine (@spec_ww_gcd t w_digits compare w_to_Z _ _ w_0 w_eq0 w_gcd_gt
+  gcd_gt_fix _ _ _ _ gcd_cont _ _ww_digits _);wwauto.
   refine (@spec_ww_gcd_gt_aux t w_digits w_0 w_WW w_0W w_compare w_opp_c w_opp
    w_opp_carry w_sub_c w_sub w_sub_carry w_gcd_gt w_add_mul_div w_head0
    w_div21 div32 _ww_zdigits ww_1 add_mul_div w_zdigits w_to_Z
@@ -769,7 +769,7 @@ refine
   exact ZnZ.spec_div21.
   exact ZnZ.spec_zdigits.
   exact spec_ww_add_mul_div.
-  refine (@spec_gcd_cont t w_digits ww_1 w_to_Z _ _ w_0 w_1 w_compare
+  refine (@spec_gcd_cont t w_digits ww_1 w_to_Z _ _ w_1 w_compare
    _ _);wwauto.
  Qed.
 

--- a/CyclicDouble/DoubleDiv.v
+++ b/CyclicDouble/DoubleDiv.v
@@ -10,7 +10,7 @@
 
 Set Implicit Arguments.
 
-Require Import ZArith.
+Require Import ZArith Lia.
 Require Import BigNumPrelude.
 Require Import DoubleType.
 Require Import DoubleBase.
@@ -20,7 +20,7 @@ Require Import DoubleSub.
 
 Local Open Scope Z_scope.
 
-Ltac zarith := auto with zarith.
+Ltac zarith := auto with zarith; fail.
 
 
 Section POS_MOD.
@@ -95,7 +95,7 @@ Section POS_MOD.
  Lemma spec_ww_pos_mod : forall w p,
        [[ww_pos_mod p w]] = [[w]] mod (2 ^ [[p]]).
  assert (HHHHH:= lt_0_wB w_digits).
- assert (F0: forall x y, x - y + y = x); auto with zarith.
+ assert (F0: forall x y, x - y + y = x) by zarith.
  intros w1 p; case (spec_to_w_Z p); intros HH1 HH2.
  unfold ww_pos_mod; case w1. reflexivity.
  intros xh xl; rewrite spec_ww_compare.
@@ -104,34 +104,34 @@ Section POS_MOD.
     intros H1.
    rewrite H1; simpl ww_to_Z.
    autorewrite with w_rewrite rm10.
-   rewrite Zplus_mod; auto with zarith.
-   rewrite Z_mod_mult; auto with zarith.
+   rewrite Zplus_mod by zarith.
+   rewrite Z_mod_mult by zarith.
    autorewrite with rm10.
-   rewrite Zmod_mod; auto with zarith.
-   rewrite Zmod_small; auto with zarith.
+   rewrite Zmod_mod by zarith.
+   rewrite Zmod_small; zarith.
    autorewrite with w_rewrite rm10.
    simpl ww_to_Z.
    rewrite spec_pos_mod.
    assert (HH0: [|low p|] = [[p]]).
      rewrite spec_low.
-     apply Zmod_small; auto with zarith.
-     case (spec_to_w_Z p); intros HHH1 HHH2; split; auto with zarith.
+     apply Zmod_small.
+     case (spec_to_w_Z p); intros HHH1 HHH2; split. zarith.
      apply Z.lt_le_trans with (1 := H1).
-     unfold base; apply Zpower2_le_lin; auto with zarith.
+     unfold base; apply Zpower2_le_lin; zarith.
    rewrite HH0.
-   rewrite Zplus_mod; auto with zarith.
+   rewrite Zplus_mod by zarith.
    unfold base.
    rewrite <- (F0 (Zpos w_digits) [[p]]).
-   rewrite Zpower_exp; auto with zarith.
+   rewrite Zpower_exp by zarith.
    rewrite Z.mul_assoc.
-   rewrite Z_mod_mult; auto with zarith.
+   rewrite Z_mod_mult by zarith.
    autorewrite with w_rewrite rm10.
-   rewrite Zmod_mod; auto with zarith.
+   rewrite Zmod_mod; zarith.
   rewrite spec_ww_compare.
     case Z.compare_spec; rewrite spec_ww_zdigits;
                      rewrite spec_zdigits; intros H2.
   replace (2^[[p]]) with wwB.
-    rewrite Zmod_small; auto with zarith.
+    rewrite Zmod_small; zarith.
   unfold base; rewrite H2.
   rewrite spec_ww_digits; auto.
   assert (HH0: [|low (ww_sub p (w_0W w_zdigits))|] =
@@ -139,55 +139,55 @@ Section POS_MOD.
     rewrite spec_low.
     rewrite spec_ww_sub.
     rewrite spec_w_0W; rewrite spec_zdigits.
-    rewrite <- Zmod_div_mod; auto with zarith.
-    rewrite Zmod_small; auto with zarith.
-    split; auto with zarith.
-    apply Z.lt_le_trans with (Zpos w_digits); auto with zarith.
-    unfold base; apply Zpower2_le_lin; auto with zarith.
-    exists wB; unfold base; rewrite <- Zpower_exp; auto with zarith.
+    rewrite <- Zmod_div_mod. 2-3: zarith.
+    rewrite Zmod_small. zarith.
+    split. zarith.
+    apply Z.lt_le_trans with (Zpos w_digits). zarith.
+    unfold base; apply Zpower2_le_lin; zarith.
+    exists wB; unfold base; rewrite <- Zpower_exp by zarith.
     rewrite spec_ww_digits;
-      apply f_equal with (f := Z.pow 2); rewrite Pos2Z.inj_xO; auto with zarith.
+      apply f_equal with (f := Z.pow 2); rewrite Pos2Z.inj_xO; zarith.
    simpl ww_to_Z; autorewrite with w_rewrite.
    rewrite spec_pos_mod; rewrite HH0.
    pattern [|xh|] at 2;
-     rewrite Z_div_mod_eq with (b := 2 ^ ([[p]] - Zpos w_digits));
-     auto with zarith.
+     rewrite Z_div_mod_eq with (b := 2 ^ ([[p]] - Zpos w_digits)) by
+     zarith.
    rewrite (fun x => (Z.mul_comm (2 ^ x))); rewrite Z.mul_add_distr_r.
-   unfold base; rewrite <- Z.mul_assoc; rewrite <- Zpower_exp;
-    auto with zarith.
-   rewrite F0; auto with zarith.
-   rewrite <- Z.add_assoc; rewrite Zplus_mod; auto with zarith.
-   rewrite Z_mod_mult; auto with zarith.
+   unfold base; rewrite <- Z.mul_assoc; rewrite <- Zpower_exp by
+    zarith.
+   rewrite F0 by zarith.
+   rewrite <- Z.add_assoc; rewrite Zplus_mod by zarith.
+   rewrite Z_mod_mult.
    autorewrite with rm10.
-   rewrite Zmod_mod; auto with zarith.
-   symmetry; apply Zmod_small; auto with zarith.
+   rewrite Zmod_mod.
+   symmetry; apply Zmod_small.
    case (spec_to_Z xh); intros U1 U2.
    case (spec_to_Z xl); intros U3 U4.
-   split; auto with zarith.
-   apply Z.add_nonneg_nonneg; auto with zarith.
-   apply Z.mul_nonneg_nonneg; auto with zarith.
+   split.
+   apply Z.add_nonneg_nonneg. 2: zarith.
+   apply Z.mul_nonneg_nonneg. 2: zarith.
    match goal with |- 0 <= ?X mod ?Y =>
-    case (Z_mod_lt X Y); auto with zarith
+    case (Z_mod_lt X Y); zarith
    end.
    match goal with |- ?X mod ?Y * ?U + ?Z < ?T =>
     apply Z.le_lt_trans with ((Y - 1) * U + Z );
-     [case (Z_mod_lt X Y); auto with zarith | idtac]
+     [case (Z_mod_lt X Y); zarith | idtac]
    end.
    match goal with |- ?X * ?U + ?Y < ?Z =>
     apply Z.le_lt_trans with (X * U + (U - 1))
    end.
-   apply Z.add_le_mono_l; auto with zarith.
-   case (spec_to_Z xl); unfold base; auto with zarith.
-   rewrite Z.mul_sub_distr_r; rewrite <- Zpower_exp; auto with zarith.
-   rewrite F0; auto with zarith.
-  rewrite Zmod_small; auto with zarith.
+   apply Z.add_le_mono_l.
+   case (spec_to_Z xl); unfold base; zarith.
+   rewrite Z.mul_sub_distr_r; rewrite <- Zpower_exp by zarith.
+   rewrite F0; zarith.
+  rewrite Zmod_small. zarith.
   case (spec_to_w_Z (WW xh xl)); intros U1 U2.
-  split; auto with zarith.
+  split. zarith.
   apply Z.lt_le_trans with (1:= U2).
   unfold base; rewrite spec_ww_digits.
-  apply Zpower_le_monotone; auto with zarith.
-  split; auto with zarith.
-  rewrite Pos2Z.inj_xO; auto with zarith.
+  apply Zpower_le_monotone. zarith.
+  split. zarith.
+  rewrite Pos2Z.inj_xO; zarith.
  Qed.
 
 End POS_MOD.
@@ -292,7 +292,7 @@ Section DoubleDiv32.
    assert (H:= spec_ww_to_Z w_digits w_to_Z spec_to_Z x).
 
   Theorem wB_div2: forall x, wB/2  <= x -> wB <= 2 * x.
-   intros x H; rewrite <- wB_div_2; apply Z.mul_le_mono_nonneg_l; auto with zarith.
+   intros x H; rewrite <- wB_div_2; apply Z.mul_le_mono_nonneg_l; zarith.
   Qed.
 
   Lemma Zmult_lt_0_reg_r_2 : forall n m : Z, 0 <= n -> 0 < m * n -> 0 < m.
@@ -337,25 +337,26 @@ Section DoubleDiv32.
     (rewrite spec_ww_add;eauto || rewrite spec_w_Bm1 || rewrite spec_w_Bm2);
    simpl ww_to_Z;try rewrite Z.mul_1_l;intros H1.
    assert (0<= ([[r]] + ([|b1|] * wB + [|b2|])) - wwB < [|b1|] * wB + [|b2|]).
-   Spec_ww_to_Z r;split;zarith.
+   Spec_ww_to_Z r; split. 2: zarith.
    rewrite H1.
    assert (H12:= wB_div2 Hle). assert (wwB <= 2 * [|b1|] * wB).
    rewrite wwB_wBwB; rewrite Z.pow_2_r; zarith.
    assert (-wwB < ([|a2|] - [|b2|]) * wB + [|a3|] < 0).
-   split. apply Z.lt_le_trans with (([|a2|] - [|b2|]) * wB);zarith.
-   rewrite wwB_wBwB;replace (-(wB^2)) with (-wB*wB);[zarith | ring].
+   split. apply Z.lt_le_trans with (([|a2|] - [|b2|]) * wB). 2: zarith.
+   rewrite wwB_wBwB;replace (-(wB^2)) with (-wB*wB);[ | ring].
    apply Z.mul_lt_mono_pos_r;zarith.
-   apply Z.le_lt_trans with (([|a2|] - [|b2|]) * wB + (wB -1));zarith.
+   apply Z.le_lt_trans with (([|a2|] - [|b2|]) * wB + (wB -1)). zarith.
    replace ( ([|a2|] - [|b2|]) * wB + (wB - 1)) with
-     (([|a2|] - [|b2|] + 1) * wB + - 1);[zarith | ring].
-   assert (([|a2|] - [|b2|] + 1) * wB <= 0);zarith.
+     (([|a2|] - [|b2|] + 1) * wB + - 1);[ | ring].
+   enough (([|a2|] - [|b2|] + 1) * wB <= 0) by zarith.
    replace 0 with (0*wB);zarith.
    replace (([|a2|] - [|b2|]) * wB + [|a3|] + wwB + ([|b1|] * wB + [|b2|]) +
               ([|b1|] * wB + [|b2|]) - wwB) with
          (([|a2|] - [|b2|]) * wB + [|a3|] + 2*[|b1|] * wB + 2*[|b2|]);
    [zarith | ring].
    rewrite <- (Zmod_unique ([[r]] + ([|b1|] * wB + [|b2|])) wwB
-             1 ([[r]] + ([|b1|] * wB + [|b2|]) - wwB));zarith;try (ring;fail).
+             1 ([[r]] + ([|b1|] * wB + [|b2|]) - wwB)).
+   3: zarith.
    split. rewrite H1;rewrite Hcmp;ring. trivial.
    Spec_ww_to_Z (WW b1 b2). simpl in HH4;zarith.
    rewrite H0;intros r;repeat
@@ -365,11 +366,11 @@ Section DoubleDiv32.
    split. rewrite H2;rewrite Hcmp;ring.
    split. Spec_ww_to_Z r;zarith.
    rewrite H2.
-   assert (([|a2|] - [|b2|]) * wB + [|a3|] < 0);zarith.
-   apply Z.le_lt_trans with (([|a2|] - [|b2|]) * wB + (wB -1));zarith.
+   enough (([|a2|] - [|b2|]) * wB + [|a3|] < 0) by zarith.
+   apply Z.le_lt_trans with (([|a2|] - [|b2|]) * wB + (wB -1)). zarith.
    replace ( ([|a2|] - [|b2|]) * wB + (wB - 1)) with
-     (([|a2|] - [|b2|] + 1) * wB + - 1);[zarith|ring].
-   assert (([|a2|] - [|b2|] + 1) * wB <= 0);zarith.
+     (([|a2|] - [|b2|] + 1) * wB + - 1);[ | ring ].
+   enough (([|a2|] - [|b2|] + 1) * wB <= 0) by zarith.
    replace 0 with (0*wB);zarith.
    (* Cas Lt *)
    assert (Hdiv21 := spec_div21 a2 Hle Hcmp);
@@ -403,12 +404,12 @@ Section DoubleDiv32.
    simpl ww_to_Z;intros H7.
    assert (0 < [|q|] - 1).
    assert (H6 : 1 <= [|q|]) by zarith.
-   Z.le_elim H6;zarith.
+   Z.le_elim H6. zarith.
    rewrite <- H6 in H2;rewrite H2 in H7.
    assert (0 < [|b1|]*wB). apply Z.mul_pos_pos;zarith.
    Spec_ww_to_Z r2. zarith.
-   rewrite (Zmod_small ([|q|] -1));zarith.
-   rewrite (Zmod_small ([|q|] -1 -1));zarith.
+   rewrite (Zmod_small ([|q|] -1)) by zarith.
+   rewrite (Zmod_small ([|q|] -1 -1)) by zarith.
    assert ([[r2]] + ([|b1|] * wB + [|b2|]) =
        wwB * 1 +
        ([|r|] * wB + [|a3|] - [|q|] * [|b2|] + 2 * ([|b1|] * wB + [|b2|]))).
@@ -420,7 +421,7 @@ Section DoubleDiv32.
    Spec_ww_to_Z (WW b1 b2). simpl in HH5.
    assert
     (0 <= [|r|]*wB + [|a3|] - [|q|]*[|b2|] + 2 * ([|b1|]*wB + [|b2|])
-       < wwB). split;try omega.
+       < wwB). split. 2: omega.
    replace (2*([|b1|]*wB+[|b2|])) with ((2*[|b1|])*wB+2*[|b2|]). 2:ring.
    assert (H12:= wB_div2 Hle). assert (wwB <= 2 * [|b1|] * wB).
    rewrite wwB_wBwB; rewrite Z.pow_2_r; zarith. omega.
@@ -432,7 +433,7 @@ Section DoubleDiv32.
             H10 H8).
    split. ring. zarith.
    intros r2;repeat (rewrite spec_pred);simpl ww_to_Z;intros H7.
-   rewrite (Zmod_small ([|q|] -1));zarith.
+   rewrite (Zmod_small ([|q|] -1)) by zarith.
    split.
    replace [[r2]] with  ([[r1]] + ([|b1|] * wB + [|b2|]) -wwB).
    rewrite H2; ring. rewrite <- H7; ring.
@@ -547,10 +548,10 @@ Section DoubleDiv21.
    generalize Hlt H ;clear Hlt H;case a1.
    intros H1 H2;simpl in H1;Spec_ww_to_Z a2.
    rewrite spec_ww_compare. case Z.compare_spec;
-   simpl;try rewrite spec_ww_1;autorewrite with rm10; intros;zarith.
-   rewrite spec_ww_sub;simpl. rewrite Zmod_small;zarith.
+   simpl;try rewrite spec_ww_1;autorewrite with rm10; intros. 1-2: zarith.
+   rewrite spec_ww_sub;simpl. rewrite Zmod_small by zarith.
    split. ring.
-   assert (wwB <= 2*[[b]]);zarith.
+   enough (wwB <= 2*[[b]]) by zarith.
    rewrite wwB_div;zarith.
    intros a1h a1l.  Spec_w_to_Z a1h;Spec_w_to_Z a1l. Spec_ww_to_Z a2.
    destruct a2 as [ |a3 a4];
@@ -560,7 +561,7 @@ Section DoubleDiv21.
      generalize (@spec_w_div32 X Y Z T U); case (w_div32 X Y Z T U);
      intros q1 r H0
    end; (assert (Eq1: wB / 2 <= [|b1|]);[
-    apply (@beta_lex (wB / 2) 0 [|b1|] [|b2|] wB); auto with zarith;
+    apply (@beta_lex (wB / 2) 0 [|b1|] [|b2|] wB); [ | zarith | zarith ];
     autorewrite with rm10;repeat rewrite (Z.mul_comm wB);
     rewrite <- wwB_div_2; trivial
    | generalize (H0 Eq1 Hlt);clear H0;destruct r as [ |r1 r2];simpl;
@@ -580,12 +581,12 @@ Section DoubleDiv21.
    rewrite spec_w_0 in H4;rewrite Z.add_0_r in H4.
    repeat rewrite Z.mul_add_distr_r. rewrite <- (Z.mul_assoc [|r1|]).
    rewrite <- Z.pow_2_r; rewrite <- wwB_wBwB;rewrite H4;simpl;ring.
-   split;[rewrite wwB_wBwB | split;zarith].
+   split;[rewrite wwB_wBwB | split; [ zarith | ] ].
    replace (([|a1h|] * wB + [|a1l|]) * wB^2 + ([|a3|] * wB + [|a4|]))
    with (([|a1h|] * wwB + [|a1l|] * wB + [|a3|])*wB+ [|a4|]).
    rewrite H1;ring. rewrite wwB_wBwB;ring.
-   change [|a4|] with (0*wB+[|a4|]);apply beta_lex_inv;zarith.
-   assert (1 <= wB/2);zarith.
+   change [|a4|] with (0*wB+[|a4|]);apply beta_lex_inv. 2-3: zarith.
+   enough (1 <= wB/2) by zarith.
     assert (H_:= wB_pos w_digits);apply Zdiv_le_lower_bound;zarith.
    destruct H2 as (H2,H3);match goal with |-context [w_div32 ?X ?Y ?Z ?T ?U] =>
      generalize (@spec_w_div32 X Y Z T U); case (w_div32 X Y Z T U);
@@ -845,8 +846,8 @@ Section DoubleDivGt.
   Proof.
    intros x p H;Spec_w_to_Z x.
    split. apply Zdiv_le_lower_bound;zarith.
-   apply Zdiv_lt_upper_bound;zarith.
-   rewrite <- Zpower_exp;zarith.
+   apply Zdiv_lt_upper_bound. zarith.
+   rewrite <- Zpower_exp by zarith.
    ring_simplify ([|p|] + (Zpos w_digits - [|p|])); unfold base in HH;zarith.
   Qed.
   Hint Resolve to_Z_div_minus_p : zarith.
@@ -883,7 +884,7 @@ Section DoubleDivGt.
         rewrite Z.mul_1_l; intros (HH1, HH2); clear HH.
    assert (wwB <= 2*[[WW bh bl]]).
     apply Z.le_trans with (2*[|bh|]*wB).
-    rewrite wwB_wBwB; rewrite Z.pow_2_r; apply Z.mul_le_mono_nonneg_r; zarith.
+    rewrite wwB_wBwB; rewrite Z.pow_2_r; apply Z.mul_le_mono_nonneg_r. zarith.
     rewrite <- wB_div_2; apply Z.mul_le_mono_nonneg_l; zarith.
     simpl ww_to_Z;rewrite Z.mul_add_distr_l;rewrite Z.mul_assoc.
     Spec_w_to_Z bl;zarith.
@@ -891,15 +892,15 @@ Section DoubleDivGt.
    rewrite spec_ww_sub;eauto.
    simpl;rewrite spec_ww_1;rewrite Z.mul_1_l;simpl.
    simpl ww_to_Z in Hgt, H, HH;rewrite Zmod_small;split;zarith.
-   case (spec_to_Z (w_head0 bh)); auto with zarith.
+   case (spec_to_Z (w_head0 bh)); zarith.
    assert ([|w_head0 bh|] < Zpos w_digits).
     destruct (Z_lt_ge_dec [|w_head0 bh|]  (Zpos w_digits));trivial.
     exfalso.
-    assert (2 ^ [|w_head0 bh|] * [|bh|] >= wB);auto with zarith.
-    apply Z.le_ge; replace wB with (wB * 1);try ring.
-    Spec_w_to_Z bh;apply Z.mul_le_mono_nonneg;zarith.
+    enough (2 ^ [|w_head0 bh|] * [|bh|] >= wB) by zarith.
+    apply Z.le_ge; replace wB with (wB * 1) by ring.
+    Spec_w_to_Z bh;apply Z.mul_le_mono_nonneg. 1, 3-4: zarith.
     unfold base;apply Zpower_le_monotone;zarith.
-   assert (HHHH : 0 < [|w_head0 bh|] < Zpos w_digits); auto with zarith.
+   assert (HHHH : 0 < [|w_head0 bh|] < Zpos w_digits) by zarith.
    assert (Hb:= Z.lt_le_incl _ _ H).
    generalize (spec_add_mul_div w_0 ah Hb)
     (spec_add_mul_div ah al Hb)
@@ -909,13 +910,13 @@ Section DoubleDivGt.
    rewrite spec_w_0; repeat rewrite Z.mul_0_l;repeat rewrite Z.add_0_l;
    rewrite Zdiv_0_l;repeat rewrite Z.add_0_r.
    Spec_w_to_Z ah;Spec_w_to_Z bh.
-   unfold base;repeat rewrite Zmod_shift_r;zarith.
+   unfold base;repeat rewrite Zmod_shift_r by zarith.
    assert (H3:=to_Z_div_minus_p ah HHHH);assert(H4:=to_Z_div_minus_p al HHHH);
    assert (H5:=to_Z_div_minus_p bl HHHH).
    rewrite Z.mul_comm in Hh.
    assert (2^[|w_head0 bh|] < wB). unfold base;apply Zpower_lt_monotone;zarith.
-   unfold base in H0;rewrite Zmod_small;zarith.
-   fold wB; rewrite (Zmod_small ([|bh|] * 2 ^ [|w_head0 bh|]));zarith.
+   unfold base in H0;rewrite Zmod_small by zarith.
+   fold wB; rewrite (Zmod_small ([|bh|] * 2 ^ [|w_head0 bh|])) by zarith.
    intros U1 U2 U3 V1 V2.
    generalize (@spec_w_div32 (w_add_mul_div (w_head0 bh) w_0 ah)
                (w_add_mul_div (w_head0 bh) ah al)
@@ -929,60 +930,60 @@ Section DoubleDivGt.
               (w_add_mul_div (w_head0 bh) bl w_0)) as (q,r).
    rewrite V1;rewrite V2. rewrite Z.mul_add_distr_r.
    rewrite <- (Z.add_assoc ([|bh|] * 2 ^ [|w_head0 bh|] * wB)).
-   unfold base;rewrite <- shift_unshift_mod;zarith. fold wB.
+   unfold base;rewrite <- shift_unshift_mod by zarith. fold wB.
    replace ([|bh|] * 2 ^ [|w_head0 bh|] * wB + [|bl|] * 2 ^ [|w_head0 bh|]) with
     ([[WW bh bl]] * 2^[|w_head0 bh|]). 2:simpl;ring.
    fold wwB. rewrite wwB_wBwB. rewrite Z.pow_2_r. rewrite U1;rewrite U2;rewrite U3.
    rewrite Z.mul_assoc. rewrite Z.mul_add_distr_r.
    rewrite (Z.add_assoc ([|ah|] / 2^(Zpos(w_digits) - [|w_head0 bh|])*wB * wB)).
    rewrite <- Z.mul_add_distr_r.  rewrite <- Z.add_assoc.
-   unfold base;repeat rewrite <- shift_unshift_mod;zarith. fold wB.
+   unfold base;repeat rewrite <- shift_unshift_mod by zarith. fold wB.
    replace ([|ah|] * 2 ^ [|w_head0 bh|] * wB + [|al|] * 2 ^ [|w_head0 bh|]) with
     ([[WW ah al]] * 2^[|w_head0 bh|]). 2:simpl;ring.
-   intros Hd;destruct Hd;zarith.
-   simpl. apply beta_lex_inv;zarith. rewrite U1;rewrite V1.
-   assert ([|ah|] / 2 ^ (Zpos (w_digits) - [|w_head0 bh|]) < wB/2);zarith.
-   apply Zdiv_lt_upper_bound;zarith.
+   intros Hd;destruct Hd. zarith.
+   simpl. apply beta_lex_inv. 2-3: zarith. rewrite U1;rewrite V1.
+   enough ([|ah|] / 2 ^ (Zpos (w_digits) - [|w_head0 bh|]) < wB/2) by zarith.
+   apply Zdiv_lt_upper_bound. zarith.
    unfold base.
    replace (2^Zpos (w_digits)) with (2^(Zpos (w_digits) - 1)*2).
-   rewrite Z_div_mult;zarith.  rewrite <- Zpower_exp;zarith.
-   apply Z.lt_le_trans with wB;zarith.
+   rewrite Z_div_mult by zarith. rewrite <- Zpower_exp by zarith.
+   apply Z.lt_le_trans with wB. zarith.
    unfold base;apply Zpower_le_monotone;zarith.
    pattern 2 at 2;replace 2 with (2^1);trivial.
-   rewrite <- Zpower_exp;zarith. ring_simplify (Zpos (w_digits) - 1 + 1);trivial.
+   rewrite <- Zpower_exp by zarith. ring_simplify (Zpos (w_digits) - 1 + 1);trivial.
    change [[WW w_0 q]] with ([|w_0|]*wB+[|q|]);rewrite spec_w_0;rewrite
    Z.mul_0_l;rewrite Z.add_0_l.
    replace [[ww_add_mul_div (ww_sub w_0 w_WW w_opp_c w_opp_carry w_sub_c w_opp w_sub w_sub_carry
        _ww_zdigits (w_0W (w_head0 bh))) W0 r]] with ([[r]]/2^[|w_head0 bh|]).
    assert (0 < 2^[|w_head0 bh|]). apply Z.pow_pos_nonneg;zarith.
    split.
-   rewrite <- (Z_div_mult [[WW ah al]] (2^[|w_head0 bh|]));zarith.
+   rewrite <- (Z_div_mult [[WW ah al]] (2^[|w_head0 bh|])) by zarith.
    rewrite H1;rewrite Z.mul_assoc;apply Z_div_plus_l;trivial.
    split;[apply Zdiv_le_lower_bound| apply Zdiv_lt_upper_bound];zarith.
    rewrite spec_ww_add_mul_div.
-   rewrite spec_ww_sub; auto with zarith.
+   rewrite spec_ww_sub by zarith.
    rewrite spec_ww_digits_.
-   change (Zpos (xO (w_digits))) with (2*Zpos (w_digits));zarith.
+   change (Zpos (xO (w_digits))) with (2*Zpos (w_digits)).
    simpl ww_to_Z;rewrite Z.mul_0_l;rewrite Z.add_0_l.
    rewrite spec_w_0W.
-   rewrite (fun x y => Zmod_small (x-y)); auto with zarith.
+   rewrite (fun x y => Zmod_small (x-y)).
    ring_simplify (2 * Zpos w_digits - (2 * Zpos w_digits - [|w_head0 bh|])).
-   rewrite Zmod_small;zarith.
-   split;[apply Zdiv_le_lower_bound| apply Zdiv_lt_upper_bound];zarith.
+   rewrite Zmod_small. zarith.
+   split;[apply Zdiv_le_lower_bound| apply Zdiv_lt_upper_bound]. 1-3: zarith.
    Spec_ww_to_Z r.
-   apply Z.lt_le_trans with wwB;zarith.
+   apply Z.lt_le_trans with wwB. zarith.
    rewrite <- (Z.mul_1_r wwB);apply Z.mul_le_mono_nonneg;zarith.
-   split; auto with zarith.
-   apply Z.le_lt_trans with (2 * Zpos w_digits); auto with zarith.
+   split. zarith.
+   apply Z.le_lt_trans with (2 * Zpos w_digits). zarith.
    unfold base, ww_digits; rewrite (Pos2Z.inj_xO w_digits).
-   apply Zpower2_lt_lin; auto with zarith.
-   rewrite spec_ww_sub; auto with zarith.
+   apply Zpower2_lt_lin; zarith.
+   rewrite spec_ww_sub by zarith.
    rewrite spec_ww_digits_; rewrite spec_w_0W.
-   rewrite Zmod_small;zarith.
-   rewrite Pos2Z.inj_xO; split; auto with zarith.
-   apply Z.le_lt_trans with (2 * Zpos w_digits); auto with zarith.
+   rewrite Zmod_small. zarith.
+   rewrite Pos2Z.inj_xO; split. zarith.
+   apply Z.le_lt_trans with (2 * Zpos w_digits). zarith.
    unfold base, ww_digits; rewrite (Pos2Z.inj_xO w_digits).
-   apply Zpower2_lt_lin; auto with zarith.
+   apply Zpower2_lt_lin; zarith.
    Qed.
 
   Lemma spec_ww_div_gt : forall a b, [[a]] > [[b]] -> 0 < [[b]] ->
@@ -1016,7 +1017,7 @@ Section DoubleDivGt.
    simpl ww_to_Z;rewrite H;trivial. simpl in Hgt;rewrite H in Hgt;trivial.
    assert ([|bh|] <= 0).
    apply beta_lex with (d:=[|al|])(b:=[|bl|]) (beta := wB);zarith.
-   assert ([|bh|] = 0);zarith. rewrite H1 in Hgt;rewrite H1;simpl in Hgt.
+   assert ([|bh|] = 0) by zarith. rewrite H1 in Hgt;rewrite H1;simpl in Hgt.
    simpl. simpl in Hpos;rewrite H1 in Hpos;simpl in Hpos.
    assert (H2:=spec_div_gt Hgt Hpos);destruct (w_div_gt al bl).
    repeat rewrite spec_w_0W;simpl;rewrite spec_w_0;simpl;trivial.
@@ -1052,7 +1053,7 @@ Section DoubleDivGt.
    intros. rewrite spec_ww_mod_gt_aux_eq;trivial.
    assert (H3 := spec_ww_div_gt_aux ah al bl H H0).
    destruct (ww_div_gt_aux ah al bh bl) as (q,r);simpl. simpl in H,H3.
-   destruct H3;apply Zmod_unique with [[q]];zarith.
+   destruct H3;apply Zmod_unique with [[q]]. zarith.
    rewrite H1;ring.
   Qed.
 
@@ -1111,7 +1112,7 @@ Section DoubleDivGt.
    simpl in Hgt;rewrite H in Hgt;trivial.
    assert ([|bh|] <= 0).
    apply beta_lex with (d:=[|al|])(b:=[|bl|]) (beta := wB);zarith.
-   assert ([|bh|] = 0);zarith. rewrite H1 in Hgt;simpl in Hgt.
+   assert ([|bh|] = 0) by zarith. rewrite H1 in Hgt;simpl in Hgt.
    simpl in Hpos;rewrite H1 in Hpos;simpl in Hpos.
    rewrite spec_w_0W;rewrite spec_w_mod_gt_eq;trivial.
    destruct (w_div_gt al bl);simpl;rewrite spec_w_0W;trivial.
@@ -1197,7 +1198,7 @@ Section DoubleDivGt.
    case Z.compare_spec; intros Hbl.
    rewrite <- Hbl;apply Zis_gcd_0.
    simpl;rewrite spec_w_0;rewrite Z.mul_0_l;rewrite Z.add_0_l.
-   apply Zis_gcd_mod;zarith.
+   apply Zis_gcd_mod. zarith.
    change ([|ah|] * wB + [|al|]) with (double_to_Z w_digits w_to_Z 1 (WW ah al)).
    rewrite <- (@spec_double_modn1 w w_digits w_zdigits w_0 w_WW w_head0 w_add_mul_div
     w_div21 w_compare w_sub w_to_Z spec_to_Z spec_w_zdigits spec_w_0 spec_w_WW spec_head0 spec_add_mul_div
@@ -1209,7 +1210,7 @@ Section DoubleDivGt.
    Spec_w_to_Z bl;exfalso;omega.
    assert (H:= spec_ww_mod_gt_aux _ _ _ Hgt Hbh).
    assert (H2 : 0 < [[WW bh bl]]).
-   simpl;Spec_w_to_Z bl. apply Z.lt_le_trans with ([|bh|]*wB);zarith.
+   simpl;Spec_w_to_Z bl. apply Z.lt_le_trans with ([|bh|]*wB). 2: zarith.
    apply Z.mul_pos_pos;zarith.
    apply Zis_gcd_mod;trivial. rewrite <- H.
    simpl in *;destruct (ww_mod_gt_aux ah al bh bl) as [ |mh ml].
@@ -1219,7 +1220,7 @@ Section DoubleDivGt.
    rewrite spec_compare, spec_w_0; case Z.compare_spec; intros Hml.
    rewrite <- Hml;simpl;apply Zis_gcd_0.
    simpl; rewrite spec_w_0; simpl.
-   apply Zis_gcd_mod;zarith.
+   apply Zis_gcd_mod. zarith.
    change ([|bh|] * wB + [|bl|]) with (double_to_Z w_digits w_to_Z 1 (WW bh bl)).
    rewrite <- (@spec_double_modn1 w w_digits w_zdigits w_0 w_WW w_head0 w_add_mul_div
    w_div21 w_compare w_sub w_to_Z spec_to_Z spec_w_zdigits spec_w_0 spec_w_WW spec_head0 spec_add_mul_div
@@ -1234,16 +1235,16 @@ Section DoubleDivGt.
    destruct (Z_mod_lt x y);zarith end.
    assert (H1:= spec_ww_mod_gt_aux _ _ _ H0 Hmh).
    assert (H3 : 0 < [[WW mh ml]]).
-   simpl;Spec_w_to_Z ml. apply Z.lt_le_trans with ([|mh|]*wB);zarith.
+   simpl;Spec_w_to_Z ml. apply Z.lt_le_trans with ([|mh|]*wB). 2: zarith.
    apply Z.mul_pos_pos;zarith.
-   apply Zis_gcd_mod;zarith. simpl in *;rewrite <- H1.
+   apply Zis_gcd_mod. zarith. simpl in *;rewrite <- H1.
    destruct (ww_mod_gt_aux bh bl mh ml) as [ |rh rl]. simpl; apply Zis_gcd_0.
    simpl;apply Hcont. simpl in H1;rewrite H1.
    apply Z.lt_gt;match goal with | |- ?x mod ?y < ?y =>
    destruct (Z_mod_lt x y);zarith end.
    apply Z.le_trans with (2^n/2).
-   apply Zdiv_le_lower_bound;zarith.
-   apply Z.le_trans with ([|bh|] * wB + [|bl|]);zarith.
+   apply Zdiv_le_lower_bound. zarith.
+   apply Z.le_trans with ([|bh|] * wB + [|bl|]). 2: zarith.
    assert (H3' := Z_div_mod_eq [[WW bh bl]] [[WW mh ml]] (Z.lt_gt _ _ H3)).
    assert (H4 : 0 <= [[WW bh bl]]/[[WW mh ml]]).
    apply Z.ge_le;apply Z_div_ge0;zarith. simpl in *;rewrite H1.
@@ -1256,10 +1257,10 @@ Section DoubleDivGt.
    simpl;pattern ([|mh|]*wB+[|ml|]) at 1;rewrite <- Z.mul_1_r;zarith.
    simpl in *;assert (H8 := Z_mod_lt [[WW bh bl]] [[WW mh ml]]);simpl in H8;
     zarith.
-   assert (H8 := Z_mod_lt [[WW bh bl]] [[WW mh ml]]);simpl in *;zarith.
-   rewrite <- H4 in H3';rewrite Z.mul_0_r in H3';simpl in H3';zarith.
-   pattern n at 1;replace n with (n-1+1);try ring.
-   rewrite Zpower_exp;zarith. change (2^1) with 2.
+   assert (H8 := Z_mod_lt [[WW bh bl]] [[WW mh ml]]);simpl in *.
+   lia.
+   pattern n at 1;replace n with (n-1+1) by ring.
+   rewrite Zpower_exp. 3: zarith. change (2^1) with 2.
    rewrite Z_div_mult;zarith.
    assert (2^1 <= 2^n). change (2^1) with 2;zarith.
    assert (H7 := @Zpower_le_monotone_inv 2 1 n);zarith.
@@ -1282,21 +1283,21 @@ Section DoubleDivGt.
    assert (0 < Zpos p). unfold Z.lt;reflexivity.
    apply spec_ww_gcd_gt_aux_body with (n := Zpos (xI p) + n);
    trivial;rewrite Pos2Z.inj_xI.
-   intros. apply IHp with (n := Zpos p + n);zarith.
+   intros. apply IHp with (n := Zpos p + n). 2: zarith.
    intros. apply IHp with (n := n );zarith.
-   apply Z.le_trans with (2 ^ (2* Zpos p + 1+ n -1));zarith.
+   apply Z.le_trans with (2 ^ (2* Zpos p + 1+ n -1)). zarith.
    apply Z.pow_le_mono_r;zarith.
    assert (0 < Zpos p). unfold Z.lt;reflexivity.
    apply spec_ww_gcd_gt_aux_body with (n := Zpos (xO p) + n );trivial.
    rewrite (Pos2Z.inj_xO p).
-   intros. apply IHp with (n := Zpos p + n - 1);zarith.
-   intros. apply IHp with (n := n -1 );zarith.
-   intros;apply Hcont;zarith.
-   apply Z.le_trans with (2^(n-1));zarith.
+   intros. apply IHp with (n := Zpos p + n - 1). 2: zarith.
+   intros. apply IHp with (n := n -1 ). 2: zarith.
+   intros;apply Hcont. zarith.
+   apply Z.le_trans with (2^(n-1)). zarith.
    apply Z.pow_le_mono_r;zarith.
-   apply Z.le_trans with (2 ^ (Zpos p + n -1));zarith.
+   apply Z.le_trans with (2 ^ (Zpos p + n -1)). zarith.
    apply Z.pow_le_mono_r;zarith.
-   apply Z.le_trans with (2 ^ (2*Zpos p + n -1));zarith.
+   apply Z.le_trans with (2 ^ (2*Zpos p + n -1)). zarith.
    apply Z.pow_le_mono_r;zarith.
    apply spec_ww_gcd_gt_aux_body with (n := n+1);trivial.
    rewrite Z.add_comm;trivial.
@@ -1362,17 +1363,18 @@ Section DoubleDiv.
    rewrite spec_ww_compare; case Z.compare_spec; intros.
    simpl;rewrite spec_ww_1;split;zarith.
    simpl;split;[ring|Spec_ww_to_Z a;zarith].
-   apply spec_ww_div_gt;auto with zarith.
+   apply spec_ww_div_gt;zarith.
   Qed.
 
   Lemma  spec_ww_mod :  forall a b, 0 < [[b]] ->
       [[ww_mod a b]] = [[a]] mod [[b]].
   Proof.
+   clear ww_1 spec_ww_1.
    intros a b Hpos;unfold ww_mod.
    rewrite spec_ww_compare; case Z.compare_spec; intros.
    simpl;apply Zmod_unique with 1;try rewrite H;zarith.
    Spec_ww_to_Z a;symmetry;apply Zmod_small;zarith.
-   apply spec_ww_mod_gt;auto with zarith.
+   apply spec_ww_mod_gt;zarith.
   Qed.
 
 
@@ -1381,8 +1383,6 @@ Section DoubleDiv.
  Variable w_compare : w -> w -> comparison.
  Variable w_eq0 : w -> bool.
  Variable w_gcd_gt : w -> w -> w.
- Variable _ww_digits : positive.
- Variable spec_ww_digits_ : _ww_digits = xO w_digits.
  Variable ww_gcd_gt_fix :
    positive -> (w -> w -> w -> w -> zn2z w) ->
              w -> w -> w -> w -> zn2z w.
@@ -1416,16 +1416,17 @@ Section DoubleDiv.
      [[WW yh yl]] <= 1 ->
       Zis_gcd [[WW xh xl]] [[WW yh yl]] [[gcd_cont xh xl yh yl]].
   Proof.
+   clear w_0 spec_w_0.
    intros xh xl yh yl Hgt' Hle. simpl in Hle.
    assert ([|yh|] = 0).
     change 1 with (0*wB+1) in Hle.
-    assert (0 <= 1 < wB). split;zarith. apply wB_pos.
+    assert (0 <= 1 < wB). split. zarith. apply wB_pos.
     assert (H1:= beta_lex _ _ _ _ _ Hle (spec_to_Z yl) H).
     Spec_w_to_Z yh;zarith.
    unfold gcd_cont; rewrite spec_compare, spec_w_1.
    case Z.compare_spec; intros Hcmpy.
    simpl;rewrite H;simpl;
-   rewrite spec_ww_1;rewrite <- Hcmpy;apply Zis_gcd_mod;zarith.
+   rewrite spec_ww_1;rewrite <- Hcmpy;apply Zis_gcd_mod. zarith.
    rewrite <- (Zmod_unique ([|xh|]*wB+[|xl|]) 1 ([|xh|]*wB+[|xl|]) 0);zarith.
    rewrite H in Hle; exfalso;zarith.
    assert (H0 : [|yl|] = 0) by (Spec_w_to_Z yl;zarith).
@@ -1438,6 +1439,9 @@ Section DoubleDiv.
      [[WW xh xl]] > [[WW yh yl]] ->
      [[WW yh yl]] <= 1 ->
       Zis_gcd [[WW xh xl]] [[WW yh yl]] [[cont xh xl yh yl]].
+
+ Variable _ww_digits : positive.
+ Variable spec_ww_digits_ : _ww_digits = xO w_digits.
 
   Definition ww_gcd_gt a b :=
    match a, b with
@@ -1459,6 +1463,7 @@ Section DoubleDiv.
   Lemma spec_ww_gcd_gt : forall a b, [[a]] > [[b]] ->
       Zis_gcd [[a]] [[b]] [[ww_gcd_gt a b]].
   Proof.
+   clear ww_1 spec_ww_1 w_1 spec_w_1.
    intros a b Hgt;unfold ww_gcd_gt.
    destruct a as [ |ah al]. simpl;apply Zis_gcd_sym;apply Zis_gcd_0.
    destruct b as [ |bh bl]. simpl;apply Zis_gcd_0.
@@ -1466,7 +1471,7 @@ Section DoubleDiv.
    simpl;rewrite H in Hgt;trivial;rewrite H;trivial;rewrite spec_w_0;simpl.
    assert ([|bh|] <= 0).
    apply beta_lex with (d:=[|al|])(b:=[|bl|]) (beta := wB);zarith.
-   Spec_w_to_Z bh;assert ([|bh|] = 0);zarith. rewrite H1 in Hgt;simpl in Hgt.
+   Spec_w_to_Z bh;assert ([|bh|] = 0) by zarith. rewrite H1 in Hgt;simpl in Hgt.
    rewrite H1;simpl;auto. clear H.
    apply spec_gcd_gt_fix with (n:= 0);trivial.
    rewrite Z.add_0_r;rewrite spec_ww_digits_.
@@ -1475,6 +1480,7 @@ Section DoubleDiv.
 
   Lemma spec_ww_gcd : forall a b, Zis_gcd [[a]] [[b]] [[ww_gcd a b]].
   Proof.
+   clear ww_1 spec_ww_1 w_1 spec_w_1.
    intros a b.
    change (ww_gcd a b) with
     (match ww_compare a b with
@@ -1484,7 +1490,7 @@ Section DoubleDiv.
      end).
    rewrite spec_ww_compare; case Z.compare_spec; intros Hcmp.
    Spec_ww_to_Z b;rewrite Hcmp.
-   apply Zis_gcd_for_euclid with 1;zarith.
+   apply Zis_gcd_for_euclid with 1.
    ring_simplify ([[b]] - 1 * [[b]]). apply Zis_gcd_0;zarith.
    apply Zis_gcd_sym;apply spec_ww_gcd_gt;zarith.
    apply spec_ww_gcd_gt;zarith.

--- a/CyclicDouble/DoubleDivn1.v
+++ b/CyclicDouble/DoubleDivn1.v
@@ -10,7 +10,7 @@
 
 Set Implicit Arguments.
 
-Require Import ZArith Ndigits.
+Require Import ZArith Ndigits Lia.
 Require Import BigNumPrelude.
 Require Import DoubleType.
 Require Import DoubleBase.
@@ -248,7 +248,7 @@ Section GENDIVN1.
    with (2^Zpos(w_digits << n) *2^Zpos(w_digits << n)).
    rewrite (Z.mul_comm (([!n|hh!] * 2 ^ [|p|] +
       [!n|hl!] / 2 ^ (Zpos (w_digits << n) - [|p|])))).
-   rewrite  Zmult_mod_distr_l;auto with zarith.
+   rewrite  Zmult_mod_distr_l by auto with zarith.
    ring.
    rewrite Zpower_exp;auto with zarith.
    assert (0 < Zpos (w_digits << n)). unfold Z.lt;reflexivity.
@@ -303,13 +303,7 @@ Section GENDIVN1.
   end.
 
  Lemma spec_double_digits:forall n, Zpos w_digits <= Zpos (w_digits << n).
- Proof.
-  induction n;simpl;auto with zarith.
-  change (Zpos (xO (w_digits << n))) with
-    (2*Zpos (w_digits << n)).
-  assert (0 < Zpos w_digits) by reflexivity.
-  auto with zarith.
- Qed.
+ Proof. induction n; simpl; lia. Qed.
 
  Lemma spec_high : forall n (x:word w n),
    [|high n x|] = [!n|x!] / 2^(Zpos (w_digits << n) - Zpos w_digits).
@@ -473,7 +467,7 @@ Section GENDIVN1.
        (w_add_mul_div (w_sub w_zdigits (w_head0 b)) w_0 r));split;
     auto with zarith.
    rewrite H9.
-   apply Zdiv_lt_upper_bound;auto with zarith.
+   apply Zdiv_lt_upper_bound. auto with zarith.
    rewrite Z.mul_comm;auto with zarith.
    exact (spec_double_to_Z w_digits w_to_Z spec_to_Z n a).
  Qed.
@@ -512,7 +506,7 @@ Section GENDIVN1.
   intros n a b H;assert (H1 := spec_double_divn1 n a H).
   assert (H2 := spec_double_modn1_aux n a b).
   rewrite H2;destruct (double_divn1 n a b) as (q,r).
-  simpl;apply Zmod_unique with (double_to_Z w_digits w_to_Z n q);auto with zarith.
+  simpl;apply Zmod_unique with (double_to_Z w_digits w_to_Z n q). auto with zarith.
   destruct H1 as (h1,h2);rewrite h1;ring.
  Qed.
 

--- a/CyclicDouble/DoubleLift.v
+++ b/CyclicDouble/DoubleLift.v
@@ -31,7 +31,6 @@ Section DoubleLift.
  Variable w_add_mul_div : w -> w -> w -> w.
  Variable ww_sub: zn2z w -> zn2z w -> zn2z w.
  Variable w_digits : positive.
- Variable ww_Digits : positive.
  Variable w_zdigits : w.
  Variable ww_zdigits : zn2z w.
  Variable low: zn2z w -> w.
@@ -107,7 +106,6 @@ Section DoubleLift.
    w_compare x y = Z.compare [|x|] [|y|].
   Variable spec_ww_compare : forall x y,
    ww_compare x y = Z.compare [[x]] [[y]].
-  Variable spec_ww_digits : ww_Digits = xO w_digits.
   Variable spec_w_head00  : forall x, [|x|] = 0 -> [|w_head0 x|] = Zpos w_digits.
   Variable spec_w_head0  : forall x,  0 < [|x|] ->
 	 wB/ 2 <= 2 ^ ([|w_head0 x|]) * [|x|] < wB.
@@ -127,42 +125,13 @@ Section DoubleLift.
  Variable spec_zdigits : [| w_zdigits |] = Zpos w_digits.
  Variable spec_low: forall x, [| low x|] = [[x]] mod wB.
 
- Variable spec_ww_zdigits : [[ww_zdigits]] = Zpos ww_Digits.
 
   Hint Resolve div_le_0 div_lt w_to_Z_wwB: lift.
   Ltac zarith := auto with zarith lift.
 
-  Lemma spec_ww_head00  : forall x, [[x]] = 0 -> [[ww_head0 x]] = Zpos ww_Digits.
-  Proof.
-  intros x; case x; unfold ww_head0.
-    intros HH; rewrite spec_ww_zdigits; auto.
-  intros xh xl; simpl; intros Hx.
-  case (spec_to_Z xh); intros Hx1 Hx2.
-  case (spec_to_Z xl); intros Hy1 Hy2.
-  assert (F1: [|xh|] = 0).
-  { Z.le_elim Hy1; auto.
-    - absurd (0 < [|xh|] * wB + [|xl|]); auto with zarith.
-      apply Z.lt_le_trans with (1 := Hy1); auto with zarith.
-      pattern [|xl|] at 1; rewrite <- (Z.add_0_l [|xl|]).
-      apply Z.add_le_mono_r; auto with zarith.
-    - Z.le_elim Hx1; auto.
-      absurd (0 < [|xh|] * wB + [|xl|]); auto with zarith.
-      rewrite <- Hy1; rewrite Z.add_0_r; auto with zarith.
-      apply Z.mul_pos_pos; auto with zarith. }
-  rewrite spec_compare. case Z.compare_spec.
-    intros H; simpl.
-    rewrite spec_w_add; rewrite spec_w_head00.
-    rewrite spec_zdigits; rewrite spec_ww_digits.
-    rewrite Pos2Z.inj_xO; auto with zarith.
-  rewrite F1 in Hx; auto with zarith.
-  rewrite spec_w_0; auto with zarith.
-  rewrite spec_w_0; auto with zarith.
-  Qed.
-
   Lemma spec_ww_head0  : forall x,  0 < [[x]] ->
 	 wwB/ 2 <= 2 ^ [[ww_head0 x]] * [[x]] < wwB.
   Proof.
-   clear spec_ww_zdigits.
    rewrite wwB_div_2;rewrite Z.mul_comm;rewrite wwB_wBwB.
    assert (U:= lt_0_wB w_digits); destruct x as [ |xh xl];simpl ww_to_Z;intros H.
    unfold Z.lt in H;discriminate H.
@@ -203,38 +172,9 @@ Section DoubleLift.
    assert (H1 := spec_to_Z xh);zarith.
   Qed.
 
-  Lemma spec_ww_tail00  : forall x, [[x]] = 0 -> [[ww_tail0 x]] = Zpos ww_Digits.
-  Proof.
-  intros x; case x; unfold ww_tail0.
-    intros HH; rewrite spec_ww_zdigits; auto.
-  intros xh xl; simpl; intros Hx.
-  case (spec_to_Z xh); intros Hx1 Hx2.
-  case (spec_to_Z xl); intros Hy1 Hy2.
-  assert (F1: [|xh|] = 0).
-  { Z.le_elim Hy1; auto.
-    - absurd (0 < [|xh|] * wB + [|xl|]); auto with zarith.
-      apply Z.lt_le_trans with (1 := Hy1); auto with zarith.
-      pattern [|xl|] at 1; rewrite <- (Z.add_0_l [|xl|]).
-      apply Z.add_le_mono_r; auto with zarith.
-    - Z.le_elim Hx1; auto.
-      absurd (0 < [|xh|] * wB + [|xl|]); auto with zarith.
-      rewrite <- Hy1; rewrite Z.add_0_r; auto with zarith.
-      apply Z.mul_pos_pos; auto with zarith. }
-  assert (F2: [|xl|] = 0).
-    rewrite F1 in Hx; auto with zarith.
-  rewrite spec_compare; case Z.compare_spec.
-    intros H; simpl.
-    rewrite spec_w_add; rewrite spec_w_tail00; auto.
-    rewrite spec_zdigits; rewrite spec_ww_digits.
-    rewrite Pos2Z.inj_xO; auto with zarith.
-  rewrite spec_w_0; auto with zarith.
-  rewrite spec_w_0; auto with zarith.
-  Qed.
-
   Lemma spec_ww_tail0  : forall x,  0 < [[x]] ->
 	 exists y, 0 <= y /\ [[x]] = (2 * y + 1) * 2 ^ [[ww_tail0 x]].
   Proof.
-   clear spec_ww_zdigits.
    destruct x as [ |xh xl];simpl ww_to_Z;intros H.
    unfold Z.lt in H;discriminate H.
    rewrite spec_compare, spec_w_0. case Z.compare_spec; intros H0.
@@ -246,7 +186,7 @@ Section DoubleLift.
      unfold base; auto with zarith.
    intros z (Hz1, Hz2); exists z; split; auto.
    rewrite spec_w_add; rewrite (fun x => Z.add_comm [|x|]).
-   rewrite spec_zdigits; rewrite Zpower_exp; auto with zarith.
+   rewrite spec_zdigits; rewrite Zpower_exp by auto with zarith.
    rewrite Z.mul_assoc; rewrite <- Hz2; auto.
 
    case (spec_to_Z (w_tail0 xh)); intros HH1 HH2.
@@ -300,7 +240,6 @@ Section DoubleLift.
       ([[WW xh xl]] * (2^[[p]]) +
        [[WW yh yl]] / (2^(Zpos (xO w_digits) - [[p]]))) mod wwB.
   Proof.
-   clear spec_ww_zdigits.
    intros xh xl yh yl p zdigits;assert (HwwB := wwB_pos w_digits).
    case (spec_to_w_Z p); intros Hv1 Hv2.
    replace (Zpos (xO w_digits)) with (Zpos w_digits + Zpos w_digits).
@@ -424,7 +363,6 @@ Section DoubleLift.
          ([[x]] * (2^[[p]]) +
           [[y]] / (2^(Zpos (xO w_digits) - [[p]]))) mod wwB.
   Proof.
-   clear spec_ww_zdigits.
    intros x y p H.
    destruct x as [ |xh xl];
    [assert (H1 := @spec_ww_add_mul_div_aux w_0 w_0)
@@ -467,6 +405,65 @@ Section DoubleLift.
      rewrite <- Zpower_exp; auto with zarith.
      apply f_equal with (f := fun x => 2 ^ x); auto with zarith.
   case (spec_to_Z xh); auto with zarith.
+  Qed.
+
+ Variable ww_Digits : positive.
+ Variable spec_ww_digits : ww_Digits = xO w_digits.
+ Variable spec_ww_zdigits : [[ww_zdigits]] = Zpos ww_Digits.
+
+  Lemma spec_ww_head00  : forall x, [[x]] = 0 -> [[ww_head0 x]] = Zpos ww_Digits.
+  Proof.
+  intros x; case x; unfold ww_head0.
+    intros HH; rewrite spec_ww_zdigits; auto.
+  intros xh xl; simpl; intros Hx.
+  case (spec_to_Z xh); intros Hx1 Hx2.
+  case (spec_to_Z xl); intros Hy1 Hy2.
+  assert (F1: [|xh|] = 0).
+  { Z.le_elim Hy1; auto.
+    - absurd (0 < [|xh|] * wB + [|xl|]); auto with zarith.
+      apply Z.lt_le_trans with (1 := Hy1); auto with zarith.
+      pattern [|xl|] at 1; rewrite <- (Z.add_0_l [|xl|]).
+      apply Z.add_le_mono_r; auto with zarith.
+    - Z.le_elim Hx1; auto.
+      absurd (0 < [|xh|] * wB + [|xl|]); auto with zarith.
+      rewrite <- Hy1; rewrite Z.add_0_r; auto with zarith.
+      apply Z.mul_pos_pos; auto with zarith. }
+  rewrite spec_compare. case Z.compare_spec.
+    intros H; simpl.
+    rewrite spec_w_add; rewrite spec_w_head00.
+    rewrite spec_zdigits; rewrite spec_ww_digits.
+    rewrite Pos2Z.inj_xO; auto with zarith.
+  rewrite F1 in Hx; auto with zarith.
+  rewrite spec_w_0; auto with zarith.
+  rewrite spec_w_0; auto with zarith.
+  Qed.
+
+  Lemma spec_ww_tail00  : forall x, [[x]] = 0 -> [[ww_tail0 x]] = Zpos ww_Digits.
+  Proof.
+  intros x; case x; unfold ww_tail0.
+    intros HH; rewrite spec_ww_zdigits; auto.
+  intros xh xl; simpl; intros Hx.
+  case (spec_to_Z xh); intros Hx1 Hx2.
+  case (spec_to_Z xl); intros Hy1 Hy2.
+  assert (F1: [|xh|] = 0).
+  { Z.le_elim Hy1; auto.
+    - absurd (0 < [|xh|] * wB + [|xl|]); auto with zarith.
+      apply Z.lt_le_trans with (1 := Hy1); auto with zarith.
+      pattern [|xl|] at 1; rewrite <- (Z.add_0_l [|xl|]).
+      apply Z.add_le_mono_r; auto with zarith.
+    - Z.le_elim Hx1; auto.
+      absurd (0 < [|xh|] * wB + [|xl|]); auto with zarith.
+      rewrite <- Hy1; rewrite Z.add_0_r; auto with zarith.
+      apply Z.mul_pos_pos; auto with zarith. }
+  assert (F2: [|xl|] = 0).
+    rewrite F1 in Hx; auto with zarith.
+  rewrite spec_compare; case Z.compare_spec.
+    intros H; simpl.
+    rewrite spec_w_add; rewrite spec_w_tail00; auto.
+    rewrite spec_zdigits; rewrite spec_ww_digits.
+    rewrite Pos2Z.inj_xO; auto with zarith.
+  rewrite spec_w_0; auto with zarith.
+  rewrite spec_w_0; auto with zarith.
   Qed.
 
  End DoubleProof.

--- a/CyclicDouble/DoubleMul.v
+++ b/CyclicDouble/DoubleMul.v
@@ -600,6 +600,7 @@ Section DoubleMul.
     let (h,l):= w_mul_add x y r in
     [|h|]*wB+[|l|] = [|x|]*[|y|] + [|r|].
   Proof.
+   assert (fake_use := w_1); clear fake_use.
    intros x y r;unfold w_mul_add;assert (H:=spec_w_mul_c x y);
    destruct (w_mul_c x y) as [ |h l];simpl;rewrite <- H.
    rewrite spec_w_0;trivial.

--- a/CyclicDouble/DoubleSqrt.v
+++ b/CyclicDouble/DoubleSqrt.v
@@ -10,12 +10,14 @@
 
 Set Implicit Arguments.
 
-Require Import ZArith.
+Require Import ZArith Lia.
 Require Import BigNumPrelude.
 Require Import DoubleType.
 Require Import DoubleBase.
 
 Local Open Scope Z_scope.
+
+Ltac zarith := auto with zarith; fail.
 
 Section DoubleSqrt.
  Variable w              : Type.
@@ -270,11 +272,11 @@ intros x; case x; simpl ww_is_even.
  simpl.
  intros w1 w2; simpl.
  unfold base.
- rewrite Zplus_mod; auto with zarith.
- rewrite (fun x y => (Zdivide_mod (x * y))); auto with zarith.
- rewrite Z.add_0_l; rewrite Zmod_mod; auto with zarith.
- apply spec_w_is_even; auto with zarith.
- apply Z.divide_mul_r; apply Zpower_divide; auto with zarith.
+ rewrite Zplus_mod by zarith.
+ rewrite (fun x y => (Zdivide_mod (x * y))).
+ rewrite Z.add_0_l; rewrite Zmod_mod by zarith.
+ apply spec_w_is_even; zarith.
+ apply Z.divide_mul_r; apply Zpower_divide; zarith.
  Qed.
 
 
@@ -283,31 +285,31 @@ intros x; case x; simpl ww_is_even.
      let (q,r) := w_div21c a1 a2 b in
      [|a1|] * wB + [|a2|] = [+|q|] *  [|b|] + [|r|] /\ 0 <= [|r|] < [|b|].
  intros a1 a2 b Hb; unfold w_div21c.
- assert (H: 0 < [|b|]); auto with zarith.
+ assert (H: 0 < [|b|]). {
  assert (U := wB_pos w_digits).
- apply Z.lt_le_trans with (2 := Hb); auto with zarith.
- apply Z.lt_le_trans with 1; auto with zarith.
- apply Zdiv_le_lower_bound; auto with zarith.
+ apply Z.lt_le_trans with (2 := Hb).
+ apply Z.lt_le_trans with 1. zarith.
+ apply Zdiv_le_lower_bound; zarith. }
  rewrite !spec_w_compare. repeat case Z.compare_spec.
  intros H1 H2; split.
- unfold interp_carry; autorewrite with w_rewrite rm10; auto with zarith.
+ unfold interp_carry; autorewrite with w_rewrite rm10.
  rewrite H1; rewrite H2; ring.
- autorewrite with w_rewrite; auto with zarith.
+ autorewrite with w_rewrite; zarith.
  intros H1 H2; split.
- unfold interp_carry; autorewrite with w_rewrite rm10; auto with zarith.
+ unfold interp_carry; autorewrite with w_rewrite rm10.
  rewrite H2; ring.
- destruct (spec_to_Z a2);auto with zarith.
+ destruct (spec_to_Z a2);zarith.
  intros H1 H2; split.
- unfold interp_carry; autorewrite with w_rewrite rm10; auto with zarith.
- rewrite H2; rewrite Zmod_small; auto with zarith.
+ unfold interp_carry; autorewrite with w_rewrite rm10.
+ rewrite H2; rewrite Zmod_small.
  ring.
- destruct (spec_to_Z a2);auto with zarith.
- rewrite spec_w_sub; auto with zarith.
- destruct (spec_to_Z a2) as [H3 H4];auto with zarith.
- rewrite Zmod_small; auto with zarith.
- split; auto with zarith.
- assert ([|a2|] < 2 * [|b|]); auto with zarith.
- apply Z.lt_le_trans with (2 * (wB / 2)); auto with zarith.
+ destruct (spec_to_Z a2);zarith.
+ rewrite spec_w_sub by zarith.
+ destruct (spec_to_Z a2) as [H3 H4].
+ rewrite Zmod_small by zarith.
+ split. zarith.
+ enough ([|a2|] < 2 * [|b|]) by zarith.
+ apply Z.lt_le_trans with (2 * (wB / 2)). 2: zarith.
  rewrite wB_div_2; auto.
  intros H1.
  match goal with |- context[w_div21 ?y ?z ?t] =>
@@ -317,29 +319,29 @@ intros x; case x; simpl ww_is_even.
  end.
  intros H1.
  assert (H2: [|w_sub a1 b|] < [|b|]).
- rewrite spec_w_sub; auto with zarith.
- rewrite Zmod_small; auto with zarith.
- assert ([|a1|] < 2 * [|b|]); auto with zarith.
- apply Z.lt_le_trans with (2 * (wB / 2)); auto with zarith.
+ rewrite spec_w_sub by zarith.
+ rewrite Zmod_small.
+ enough ([|a1|] < 2 * [|b|]) by zarith.
+ apply Z.lt_le_trans with (2 * (wB / 2)). 2: zarith.
  rewrite wB_div_2; auto.
- destruct (spec_to_Z a1);auto with zarith.
- destruct (spec_to_Z a1);auto with zarith.
+ destruct (spec_to_Z a1);zarith.
+ destruct (spec_to_Z a1);zarith.
  match goal with |- context[w_div21 ?y ?z ?t] =>
    generalize (@spec_w_div21 y z t Hb H2);
    case (w_div21 y z t); autorewrite with w_rewrite;
    auto
  end.
  intros w0 w1; replace [+|C1 w0|] with (wB + [|w0|]).
- rewrite Zmod_small; auto with zarith.
+ rewrite Zmod_small.
  intros (H3, H4); split; auto.
  rewrite Z.mul_add_distr_r.
  rewrite <- Z.add_assoc; rewrite <- H3; ring.
- split; auto with zarith.
- assert ([|a1|] < 2 * [|b|]); auto with zarith.
- apply Z.lt_le_trans with (2 * (wB / 2)); auto with zarith.
+ split. zarith.
+ assert ([|a1|] < 2 * [|b|]).
+ apply Z.lt_le_trans with (2 * (wB / 2)). 2: zarith.
  rewrite wB_div_2; auto.
- destruct (spec_to_Z a1);auto with zarith.
- destruct (spec_to_Z a1);auto with zarith.
+ destruct (spec_to_Z a1);zarith.
+ destruct (spec_to_Z a1);zarith.
  simpl; case wB; auto.
  Qed.
 
@@ -352,19 +354,19 @@ intros x; case x; simpl ww_is_even.
  intros w1.
  assert (Hp: [|w_pred w_zdigits|] = Zpos w_digits - 1).
    rewrite spec_pred; rewrite spec_w_zdigits.
-   rewrite Zmod_small; auto with zarith.
-   split; auto with zarith.
-   apply Z.lt_le_trans with (Zpos w_digits); auto with zarith.
-   unfold base; apply Zpower2_le_lin; auto with zarith.
- rewrite spec_w_add_mul_div; auto with zarith.
+   rewrite Zmod_small. zarith.
+   split. zarith.
+   apply Z.lt_le_trans with (Zpos w_digits). zarith.
+   unfold base; apply Zpower2_le_lin; zarith.
+ rewrite spec_w_add_mul_div by zarith.
  autorewrite with w_rewrite rm10.
  match goal with |- context[?X - ?Y] =>
   replace (X - Y) with 1
  end.
- rewrite Z.pow_1_r; rewrite Zmod_small; auto with zarith.
- destruct (spec_to_Z w1) as [H1 H2];auto with zarith.
- split; auto with zarith.
- apply Zdiv_lt_upper_bound; auto with zarith.
+ rewrite Z.pow_1_r. rewrite Zmod_small. zarith.
+ destruct (spec_to_Z w1) as [H1 H2].
+ split. zarith.
+ apply Zdiv_lt_upper_bound; zarith.
  rewrite Hp; ring.
  Qed.
 
@@ -374,54 +376,52 @@ intros x; case x; simpl ww_is_even.
  intros w1.
  assert (Hp: [|w_pred w_zdigits|] = Zpos w_digits - 1).
    rewrite spec_pred; rewrite spec_w_zdigits.
-   rewrite Zmod_small; auto with zarith.
-   split; auto with zarith.
-   apply Z.lt_le_trans with (Zpos w_digits); auto with zarith.
-   unfold base; apply Zpower2_le_lin; auto with zarith.
- autorewrite with w_rewrite rm10; auto with zarith.
+   rewrite Zmod_small. zarith.
+   split. zarith.
+   apply Z.lt_le_trans with (Zpos w_digits). zarith.
+   unfold base; apply Zpower2_le_lin; zarith.
+ autorewrite with w_rewrite rm10. 2: zarith.
  match goal with |- context[?X - ?Y] =>
   replace (X - Y) with 1
  end; rewrite Hp; try ring.
- rewrite Pos2Z.inj_sub_max; auto with zarith.
- rewrite Z.max_r; auto with zarith.
- rewrite Z.pow_1_r; rewrite Zmod_small; auto with zarith.
- destruct (spec_to_Z w1) as [H1 H2];auto with zarith.
- split; auto with zarith.
+ rewrite Pos2Z.inj_sub_max by zarith.
+ rewrite Z.max_r by zarith.
+ rewrite Z.pow_1_r; rewrite Zmod_small. zarith.
+ destruct (spec_to_Z w1) as [H1 H2].
+ split. zarith.
  unfold base.
  match goal with |- _ < _ ^ ?X =>
- assert (tmp: forall p, 1 + (p - 1) = p); auto with zarith;
+ assert (tmp: forall p, 1 + (p - 1) = p) by zarith;
   rewrite <- (tmp X); clear tmp
  end.
- rewrite Zpower_exp; try rewrite Z.pow_1_r; auto with zarith.
- assert (tmp: forall p, 1 + (p -1) - 1 = p - 1); auto with zarith;
-  rewrite tmp; clear tmp; auto with zarith.
+ rewrite Zpower_exp by zarith. rewrite Z.pow_1_r.
+ assert (tmp: forall p, 1 + (p -1) - 1 = p - 1) by zarith;
+  rewrite tmp; clear tmp.
  match goal with |- ?X + ?Y < _ =>
- assert (Y < X); auto with zarith
+ enough (Y < X) by zarith
  end.
- apply Zdiv_lt_upper_bound; auto with zarith.
- pattern 2 at 2; rewrite <- Z.pow_1_r; rewrite <- Zpower_exp;
-  auto with zarith.
- assert (tmp: forall p, (p - 1) + 1 = p); auto with zarith;
-  rewrite tmp; clear tmp; auto with zarith.
+ apply Zdiv_lt_upper_bound. zarith.
+ pattern 2 at 2; rewrite <- Z.pow_1_r; rewrite <- Zpower_exp by zarith.
+ assert (tmp: forall p, (p - 1) + 1 = p) by zarith;
+  rewrite tmp; clear tmp; zarith.
  Qed.
 
  Theorem add_mult_mult_2: forall w,
     [|w_add_mul_div w_1 w w_0|] = 2 * [|w|] mod wB.
  intros w1.
- autorewrite with w_rewrite rm10; auto with zarith.
- rewrite Z.pow_1_r; auto with zarith.
+ autorewrite with w_rewrite rm10. 2: zarith.
  rewrite Z.mul_comm; auto.
  Qed.
 
  Theorem ww_add_mult_mult_2: forall w,
     [[ww_add_mul_div (w_0W w_1) w W0]] = 2 * [[w]] mod wwB.
  intros w1.
- rewrite spec_ww_add_mul_div; auto with zarith.
+ rewrite spec_ww_add_mul_div.
  autorewrite with w_rewrite rm10.
  rewrite spec_w_0W; rewrite spec_w_1.
- rewrite Z.pow_1_r; auto with zarith.
- rewrite Z.mul_comm; auto.
- rewrite spec_w_0W; rewrite spec_w_1; auto with zarith.
+ rewrite Z.pow_1_r by zarith.
+ rewrite Z.mul_comm; easy.
+ rewrite spec_w_0W; rewrite spec_w_1.
  red; simpl; intros; discriminate.
  Qed.
 
@@ -429,48 +429,41 @@ intros x; case x; simpl ww_is_even.
     [[ww_add_mul_div (w_0W w_1) w wwBm1]] =
       (2 * [[w]] + 1) mod wwB.
  intros w1.
- rewrite spec_ww_add_mul_div; auto with zarith.
- rewrite spec_w_0W; rewrite spec_w_1; auto with zarith.
- rewrite Z.pow_1_r; auto with zarith.
- f_equal; auto.
- rewrite Z.mul_comm; f_equal; auto.
+ rewrite spec_ww_add_mul_div;
+   rewrite spec_w_0W; rewrite spec_w_1.
+ 2: lia.
+ rewrite Z.pow_1_r.
+ f_equal.
+ rewrite Z.mul_comm; f_equal.
  autorewrite with w_rewrite rm10.
  unfold ww_digits, base.
- symmetry; apply Zdiv_unique with (r := 2 ^ (Zpos (ww_digits w_digits) - 1) -1);
-  auto with zarith.
- unfold ww_digits; split; auto with zarith.
- match goal with  |- 0 <= ?X - 1 =>
-   assert (0 < X); auto with zarith
- end.
- apply Z.pow_pos_nonneg; auto with zarith.
- match goal with  |- 0 <= ?X - 1 =>
-   assert (0 < X); auto with zarith; red; reflexivity
- end.
+ symmetry; apply Zdiv_unique with (r := 2 ^ (Zpos (ww_digits w_digits) - 1) -1).
+ {
+   unfold ww_digits; split. 2: lia.
+   match goal with  |- 0 <= ?X - 1 =>
+     enough (0 < X) by lia
+   end.
+   apply Z.pow_pos_nonneg; lia.
+ }
  unfold ww_digits; autorewrite with rm10.
- assert (tmp: forall p q r, p + (q - r) = p + q - r); auto with zarith;
+ assert (tmp: forall p q r, p + (q - r) = p + q - r) by zarith;
   rewrite tmp; clear tmp.
- assert (tmp: forall p, p + p = 2 * p); auto with zarith;
+ assert (tmp: forall p, p + p = 2 * p) by zarith;
   rewrite tmp; clear tmp.
  f_equal; auto.
- pattern 2 at 2; rewrite <- Z.pow_1_r; rewrite <- Zpower_exp;
-  auto with zarith.
- assert (tmp: forall p, 1 + (p - 1) = p); auto with zarith;
+ pattern 2 at 2; rewrite <- Z.pow_1_r; rewrite <- Zpower_exp by lia.
+ assert (tmp: forall p, 1 + (p - 1) = p) by zarith;
   rewrite tmp; clear tmp; auto.
- match goal with  |- ?X - 1 >= 0 =>
-   assert (0 < X); auto with zarith; red; reflexivity
- end.
- rewrite spec_w_0W; rewrite spec_w_1; auto with zarith.
- red; simpl; intros; discriminate.
  Qed.
 
  Theorem Zplus_mod_one: forall a1 b1, 0 < b1 -> (a1 + b1) mod b1 = a1 mod b1.
- intros a1 b1 H; rewrite Zplus_mod; auto with zarith.
- rewrite Z_mod_same; try rewrite Z.add_0_r; auto with zarith.
+ intros a1 b1 H; rewrite Zplus_mod by zarith.
+ rewrite Z_mod_same by zarith; rewrite Z.add_0_r.
  apply Zmod_mod; auto.
  Qed.
 
  Lemma C1_plus_wB: forall x, [+|C1 x|] = wB + [|x|].
- unfold interp_carry; auto with zarith.
+ unfold interp_carry; zarith.
  Qed.
 
  Theorem  spec_w_div2s : forall a1 a2 b,
@@ -478,11 +471,11 @@ intros x; case x; simpl ww_is_even.
      let (q,r) := w_div2s a1 a2 b in
      [+|a1|] * wB + [|a2|] = [+|q|] *  (2 * [|b|]) + [+|r|] /\ 0 <= [+|r|] < 2 * [|b|].
  intros a1 a2 b H.
- assert (HH: 0 < [|b|]); auto with zarith.
+ assert (HH: 0 < [|b|]). {
  assert (U := wB_pos w_digits).
- apply Z.lt_le_trans with (2 := H); auto with zarith.
- apply Z.lt_le_trans with 1; auto with zarith.
- apply Zdiv_le_lower_bound; auto with zarith.
+ apply Z.lt_le_trans with (2 := H).
+ apply Z.lt_le_trans with 1. zarith.
+ apply Zdiv_le_lower_bound; zarith. }
  unfold w_div2s; case a1; intros w0 H0.
  match goal with |- context[w_div21c ?y ?z ?t] =>
    generalize (@spec_w_div21c y z t H);
@@ -497,18 +490,18 @@ intros x; case x; simpl ww_is_even.
  end.
  repeat rewrite C0_id.
  rewrite add_mult_div_2.
- intros H1; split; auto with zarith.
+ intros H1; split. 2: zarith.
  rewrite Hw1.
- pattern [|w2|] at 1; rewrite (Z_div_mod_eq [|w2|] 2);
-  auto with zarith.
+ pattern [|w2|] at 1; rewrite (Z_div_mod_eq [|w2|] 2) by
+  zarith.
  rewrite H1; ring.
  repeat rewrite C0_id.
  rewrite add_mult_div_2.
- rewrite spec_w_add_c; auto with zarith.
- intros H1; split; auto with zarith.
+ rewrite spec_w_add_c by zarith.
+ intros H1; split. 2: zarith.
  rewrite Hw1.
- pattern [|w2|] at 1; rewrite (Z_div_mod_eq [|w2|] 2);
-  auto with zarith.
+ pattern [|w2|] at 1; rewrite (Z_div_mod_eq [|w2|] 2) by
+  zarith.
  rewrite H1; ring.
  intros w2; rewrite C1_plus_wB.
  intros (Hw1, Hw2).
@@ -517,37 +510,37 @@ intros x; case x; simpl ww_is_even.
    case (w_is_even y)
  end.
  repeat rewrite C0_id.
- intros H1; split; auto with zarith.
+ intros H1; split. 2: zarith.
  rewrite Hw1.
- pattern [|w2|] at 1; rewrite (Z_div_mod_eq [|w2|] 2);
-  auto with zarith.
+ pattern [|w2|] at 1; rewrite (Z_div_mod_eq [|w2|] 2) by
+  zarith.
  rewrite H1.
  repeat rewrite C0_id.
  rewrite add_mult_div_2_plus_1; unfold base.
  match goal with |- context[_ ^ ?X] =>
- assert (tmp: forall p, 1 + (p - 1) = p); auto with zarith;
-  rewrite <- (tmp X); clear tmp; rewrite Zpower_exp;
-  try rewrite Z.pow_1_r; auto with zarith
+ assert (tmp: forall p, 1 + (p - 1) = p) by zarith;
+  rewrite <- (tmp X); clear tmp; rewrite Zpower_exp by zarith;
+  rewrite Z.pow_1_r
  end.
- rewrite Pos2Z.inj_sub_max; auto with zarith.
- rewrite Z.max_r; auto with zarith.
+ rewrite Pos2Z.inj_sub_max.
+ rewrite Z.max_r by zarith.
  ring.
  repeat rewrite C0_id.
- rewrite spec_w_add_c; auto with zarith.
- intros H1; split; auto with zarith.
+ rewrite spec_w_add_c.
+ intros H1; split. 2: zarith.
  rewrite add_mult_div_2_plus_1.
  rewrite Hw1.
- pattern [|w2|] at 1; rewrite (Z_div_mod_eq [|w2|] 2);
-  auto with zarith.
+ pattern [|w2|] at 1; rewrite (Z_div_mod_eq [|w2|] 2) by
+  zarith.
  rewrite H1.
  unfold base.
  match goal with |- context[_ ^ ?X] =>
- assert (tmp: forall p, 1 + (p - 1) = p); auto with zarith;
-  rewrite <- (tmp X); clear tmp; rewrite Zpower_exp;
-  try rewrite Z.pow_1_r; auto with zarith
+ assert (tmp: forall p, 1 + (p - 1) = p) by zarith;
+  rewrite <- (tmp X); clear tmp; rewrite Zpower_exp by zarith;
+  rewrite Z.pow_1_r
  end.
- rewrite Pos2Z.inj_sub_max; auto with zarith.
- rewrite Z.max_r; auto with zarith.
+ rewrite Pos2Z.inj_sub_max.
+ rewrite Z.max_r by zarith.
  ring.
  repeat rewrite C1_plus_wB in H0.
  rewrite C1_plus_wB.
@@ -558,88 +551,88 @@ intros x; case x; simpl ww_is_even.
  end.
  intros c w1; case c.
  intros w2 (Hw1, Hw2); rewrite C0_id in Hw1.
- rewrite <- Zplus_mod_one in Hw1; auto with zarith.
- rewrite Zmod_small in Hw1; auto with zarith.
+ rewrite <- Zplus_mod_one in Hw1.
+ rewrite Zmod_small in Hw1.
  match goal with |- context[w_is_even ?y] =>
    generalize (spec_w_is_even y);
    case (w_is_even y)
  end.
  repeat rewrite C0_id.
- intros H1; split; auto with zarith.
+ intros H1; split. 2: zarith.
  rewrite add_mult_div_2_plus_1.
- replace (wB + [|w0|]) with ([|b|] + ([|w0|] - [|b|] + wB));
-  auto with zarith.
+ replace (wB + [|w0|]) with ([|b|] + ([|w0|] - [|b|] + wB)) by
+  zarith.
  rewrite Z.mul_add_distr_r; rewrite <- Z.add_assoc.
  rewrite Hw1.
- pattern [|w2|] at 1; rewrite (Z_div_mod_eq [|w2|] 2);
-  auto with zarith.
+ pattern [|w2|] at 1; rewrite (Z_div_mod_eq [|w2|] 2) by
+  zarith.
  rewrite H1; unfold base.
  match goal with |- context[_ ^ ?X] =>
- assert (tmp: forall p, 1 + (p - 1) = p); auto with zarith;
-  rewrite <- (tmp X); clear tmp; rewrite Zpower_exp;
-  try rewrite Z.pow_1_r; auto with zarith
+ assert (tmp: forall p, 1 + (p - 1) = p) by zarith;
+  rewrite <- (tmp X); clear tmp; rewrite Zpower_exp by zarith;
+  rewrite Z.pow_1_r
  end.
- rewrite Pos2Z.inj_sub_max; auto with zarith.
- rewrite Z.max_r; auto with zarith.
+ rewrite Pos2Z.inj_sub_max.
+ rewrite Z.max_r by zarith.
  ring.
  repeat rewrite C0_id.
  rewrite add_mult_div_2_plus_1.
- rewrite spec_w_add_c; auto with zarith.
- intros H1; split; auto with zarith.
- replace (wB + [|w0|]) with ([|b|] + ([|w0|] - [|b|] + wB));
-  auto with zarith.
+ rewrite spec_w_add_c.
+ intros H1; split. 2: zarith.
+ replace (wB + [|w0|]) with ([|b|] + ([|w0|] - [|b|] + wB)) by
+  zarith.
  rewrite Z.mul_add_distr_r; rewrite <- Z.add_assoc.
  rewrite Hw1.
- pattern [|w2|] at 1; rewrite (Z_div_mod_eq [|w2|] 2);
-  auto with zarith.
+ pattern [|w2|] at 1; rewrite (Z_div_mod_eq [|w2|] 2) by
+  zarith.
  rewrite H1; unfold base.
  match goal with |- context[_ ^ ?X] =>
- assert (tmp: forall p, 1 + (p - 1) = p); auto with zarith;
-  rewrite <- (tmp X); clear tmp; rewrite Zpower_exp;
-  try rewrite Z.pow_1_r; auto with zarith
+ assert (tmp: forall p, 1 + (p - 1) = p) by zarith;
+  rewrite <- (tmp X); clear tmp; rewrite Zpower_exp by zarith;
+  rewrite Z.pow_1_r
  end.
- rewrite Pos2Z.inj_sub_max; auto with zarith.
- rewrite Z.max_r; auto with zarith.
+ rewrite Pos2Z.inj_sub_max.
+ rewrite Z.max_r by zarith.
  ring.
- split; auto with zarith.
- destruct (spec_to_Z b);auto with zarith.
- destruct (spec_to_Z w0);auto with zarith.
- destruct (spec_to_Z b);auto with zarith.
- destruct (spec_to_Z b);auto with zarith.
+ split.
+ destruct (spec_to_Z b).
+ destruct (spec_to_Z w0);zarith.
+ destruct (spec_to_Z b);zarith.
+ destruct (spec_to_Z b);zarith.
  intros w2; rewrite C1_plus_wB.
- rewrite <- Zplus_mod_one; auto with zarith.
- rewrite Zmod_small; auto with zarith.
+ rewrite <- Zplus_mod_one.
+ rewrite Zmod_small.
  intros (Hw1, Hw2).
  match goal with |- context[w_is_even ?y] =>
    generalize (spec_w_is_even y);
    case (w_is_even y)
  end.
  repeat (rewrite C0_id || rewrite C1_plus_wB).
- intros H1; split; auto with zarith.
+ intros H1; split. 2: zarith.
  rewrite add_mult_div_2.
- replace (wB + [|w0|]) with ([|b|] + ([|w0|] - [|b|] + wB));
-  auto with zarith.
+ replace (wB + [|w0|]) with ([|b|] + ([|w0|] - [|b|] + wB)) by
+  zarith.
  rewrite Z.mul_add_distr_r; rewrite <- Z.add_assoc.
  rewrite Hw1.
- pattern [|w2|] at 1; rewrite (Z_div_mod_eq [|w2|] 2);
-  auto with zarith.
+ pattern [|w2|] at 1; rewrite (Z_div_mod_eq [|w2|] 2) by
+  zarith.
  rewrite H1; ring.
  repeat (rewrite C0_id || rewrite C1_plus_wB).
- rewrite spec_w_add_c; auto with zarith.
- intros H1; split; auto with zarith.
+ rewrite spec_w_add_c by zarith.
+ intros H1; split. 2: zarith.
  rewrite add_mult_div_2.
- replace (wB + [|w0|]) with ([|b|] + ([|w0|] - [|b|] + wB));
-  auto with zarith.
+ replace (wB + [|w0|]) with ([|b|] + ([|w0|] - [|b|] + wB)) by
+  zarith.
  rewrite Z.mul_add_distr_r; rewrite <- Z.add_assoc.
  rewrite Hw1.
- pattern [|w2|] at 1; rewrite (Z_div_mod_eq [|w2|] 2);
-  auto with zarith.
+ pattern [|w2|] at 1; rewrite (Z_div_mod_eq [|w2|] 2) by
+  zarith.
  rewrite H1; ring.
- split; auto with zarith.
- destruct (spec_to_Z b);auto with zarith.
- destruct (spec_to_Z w0);auto with zarith.
- destruct (spec_to_Z b);auto with zarith.
- destruct (spec_to_Z b);auto with zarith.
+ split.
+ destruct (spec_to_Z b).
+ destruct (spec_to_Z w0);zarith.
+ destruct (spec_to_Z b);zarith.
+ destruct (spec_to_Z b);zarith.
  Qed.
 
  Theorem wB_div_4:  4 * (wB / 4) = wB.
@@ -648,29 +641,29 @@ intros x; case x; simpl ww_is_even.
   assert (2 ^ Zpos w_digits =
               4 * (2 ^ (Zpos w_digits - 2))).
   change 4 with (2 ^ 2).
-  rewrite <- Zpower_exp; auto with zarith.
-  f_equal; auto with zarith.
+  rewrite <- Zpower_exp by zarith.
+  f_equal; zarith.
   rewrite H.
   rewrite (fun x => (Z.mul_comm 4 (2 ^x))).
-  rewrite Z_div_mult; auto with zarith.
+  rewrite Z_div_mult; zarith.
  Qed.
 
  Theorem Zsquare_mult: forall p, p ^ 2 = p * p.
  intros p; change 2 with (1 + 1); rewrite Zpower_exp;
-  try rewrite Z.pow_1_r; auto with zarith.
+  try rewrite Z.pow_1_r; zarith.
  Qed.
 
  Theorem Zsquare_pos: forall p, 0 <= p ^ 2.
  intros p; case (Z.le_gt_cases 0 p); intros H1.
- rewrite Zsquare_mult; apply Z.mul_nonneg_nonneg; auto with zarith.
+ rewrite Zsquare_mult; apply Z.mul_nonneg_nonneg; zarith.
  rewrite Zsquare_mult; replace (p * p) with ((- p) * (- p)); try ring.
- apply Z.mul_nonneg_nonneg; auto with zarith.
+ apply Z.mul_nonneg_nonneg; zarith.
  Qed.
 
  Lemma spec_split: forall x,
   [|fst (split x)|] * wB + [|snd (split x)|] = [[x]].
  intros x; case x; simpl; autorewrite with w_rewrite;
-  auto with zarith.
+  zarith.
  Qed.
 
  Theorem mult_wwB: forall x y, [|x|] * [|y|] < wwB.
@@ -678,9 +671,7 @@ intros x; case x; simpl ww_is_even.
   intros x y; rewrite wwB_wBwB; rewrite Z.pow_2_r.
   generalize (spec_to_Z x); intros U.
   generalize (spec_to_Z y); intros U1.
-  apply Z.le_lt_trans with ((wB -1 ) * (wB - 1)); auto with zarith.
-  apply Z.mul_le_mono_nonneg; auto with zarith.
-  rewrite ?Z.mul_sub_distr_l, ?Z.mul_sub_distr_r; auto with zarith.
+  nia.
  Qed.
  Hint Resolve mult_wwB.
 
@@ -689,38 +680,40 @@ intros x; case x; simpl ww_is_even.
        let (s,r) := ww_sqrt2 x y in
           [||WW x y||] = [[s]] ^ 2 + [+[r]] /\
           [+[r]] <= 2 * [[s]].
+ Proof.
+ assert (fake_use := ww_zdigits); clear fake_use.
  intros x y H; unfold ww_sqrt2.
  repeat match goal with |- context[split ?x] =>
    generalize (spec_split x); case (split x)
  end; simpl @fst; simpl @snd.
  intros w0 w1 Hw0 w2 w3 Hw1.
- assert (U: wB/4 <= [|w2|]).
+ assert (U: wB/4 <= [|w2|]). {
  case (Z.le_gt_cases (wB / 4) [|w2|]); auto; intros H1.
  contradict H; apply Z.lt_nge.
  rewrite wwB_wBwB; rewrite Z.pow_2_r.
  pattern wB at 1; rewrite <- wB_div_4; rewrite <- Z.mul_assoc;
    rewrite Z.mul_comm.
- rewrite Z_div_mult; auto with zarith.
+ rewrite Z_div_mult by zarith.
  rewrite <- Hw1.
  match goal with |- _  < ?X =>
-  pattern X; rewrite <- Z.add_0_r; apply beta_lex_inv;
-  auto with zarith
+  pattern X; rewrite <- Z.add_0_r; apply beta_lex_inv
  end.
- destruct (spec_to_Z w3);auto with zarith.
+ 1-2: zarith.
+ destruct (spec_to_Z w3);zarith.
+ }
  generalize (@spec_w_sqrt2 w2 w3 U); case (w_sqrt2 w2 w3).
  intros w4 c (H1, H2).
- assert (U1: wB/2 <= [|w4|]).
- case (Z.le_gt_cases (wB/2) [|w4|]); auto with zarith.
+ assert (U1: wB/2 <= [|w4|]). {
+ case (Z.le_gt_cases (wB/2) [|w4|]). zarith.
  intros U1.
- assert (U2 : [|w4|] <= wB/2 -1); auto with zarith.
- assert (U3 : [|w4|] ^ 2 <= wB/4 * wB - wB + 1); auto with zarith.
+ assert (U2 : [|w4|] <= wB/2 -1) by zarith.
+ assert (U3 : [|w4|] ^ 2 <= wB/4 * wB - wB + 1).
  match goal with |- ?X ^ 2 <= ?Y =>
   rewrite Zsquare_mult;
   replace Y with ((wB/2 - 1) * (wB/2 -1))
  end.
- apply Z.mul_le_mono_nonneg; auto with zarith.
- destruct (spec_to_Z w4);auto with zarith.
- destruct (spec_to_Z w4);auto with zarith.
+ apply Z.mul_le_mono_nonneg. 2, 4: zarith.
+ 1-2: destruct (spec_to_Z w4);zarith.
  pattern wB at 4 5; rewrite <- wB_div_2.
  rewrite Z.mul_assoc.
  replace ((wB / 4) * 2) with (wB / 2).
@@ -728,34 +721,36 @@ intros x; case x; simpl ww_is_even.
  pattern wB at 1; rewrite <- wB_div_4.
  change 4 with (2 * 2).
  rewrite <- Z.mul_assoc; rewrite (Z.mul_comm 2).
- rewrite Z_div_mult; try ring; auto with zarith.
- assert (U4 : [+|c|]  <= wB -2); auto with zarith.
+ rewrite Z_div_mult; try ring; zarith.
+ assert (U4 : [+|c|]  <= wB -2).
  apply Z.le_trans with (1 := H2).
  match goal with |- ?X <= ?Y =>
-  replace Y with (2 * (wB/ 2 - 1)); auto with zarith
+  replace Y with (2 * (wB/ 2 - 1))
  end.
- pattern wB at 2; rewrite <- wB_div_2; auto with zarith.
+ zarith.
+ pattern wB at 2; rewrite <- wB_div_2; zarith.
  match type of H1 with ?X = _ =>
   assert (U5: X < wB / 4 * wB)
  end.
- rewrite H1; auto with zarith.
+ rewrite H1; zarith.
  contradict U; apply Z.lt_nge.
- apply Z.mul_lt_mono_pos_r with wB; auto with zarith.
- destruct (spec_to_Z w4);auto with zarith.
+ apply Z.mul_lt_mono_pos_r with wB.
+ destruct (spec_to_Z w4);zarith.
  apply Z.le_lt_trans with (2 := U5).
  unfold ww_to_Z, zn2z_to_Z.
- destruct (spec_to_Z w3);auto with zarith.
+ destruct (spec_to_Z w3);zarith.
+ }
  generalize (@spec_w_div2s c w0 w4 U1 H2).
  case (w_div2s c w0 w4).
  intros c0; case c0; intros w5;
    repeat (rewrite C0_id || rewrite C1_plus_wB).
- intros c1; case c1; intros w6;
+ - intros c1; case c1; intros w6;
    repeat (rewrite C0_id || rewrite C1_plus_wB).
- intros (H3, H4).
+ + intros (H3, H4).
  match goal with |- context [ww_sub_c ?y ?z] =>
   generalize (spec_ww_sub_c y z); case (ww_sub_c y z)
  end.
- intros z; change [-[C0 z]] with ([[z]]).
+ * intros z; change [-[C0 z]] with ([[z]]).
  change [+[C0 z]] with ([[z]]).
  intros H5; rewrite spec_w_square_c in H5;
   auto.
@@ -777,21 +772,20 @@ intros x; case x; simpl ww_is_even.
  match goal with |- ?X - ?Y * ?Y <= _ =>
   assert (V := Zsquare_pos Y);
   rewrite Zsquare_mult in V;
-  apply Z.le_trans with X; auto with zarith;
+  apply Z.le_trans with X; [ zarith | ];
   clear V
  end.
  match goal with |- ?X * wB + ?Y <= 2 * (?Z * wB + ?T) =>
-  apply Z.le_trans with ((2 * Z - 1) * wB + wB); auto with zarith
+  apply Z.le_trans with ((2 * Z - 1) * wB + wB)
  end.
- destruct (spec_to_Z w1);auto with zarith.
+ destruct (spec_to_Z w1);zarith.
  match goal with |- ?X <= _ =>
-  replace X with (2 * [|w4|] * wB); auto with zarith
+  replace X with (2 * [|w4|] * wB) by ring
  end.
  rewrite Z.mul_add_distr_l; rewrite Z.mul_assoc.
- destruct (spec_to_Z w5); auto with zarith.
- ring.
- intros z; replace [-[C1 z]] with (- wwB + [[z]]).
- 2: simpl; case wwB; auto with zarith.
+ destruct (spec_to_Z w5); zarith.
+ * intros z; replace [-[C1 z]] with (- wwB + [[z]]).
+ 2: simpl; case wwB; zarith.
  intros H5; rewrite spec_w_square_c in H5;
   auto.
  match goal with |- context [ww_pred_c ?y] =>
@@ -801,12 +795,12 @@ intros x; case x; simpl ww_is_even.
  rewrite ww_add_mult_mult_2.
  rewrite spec_ww_add_c.
  rewrite spec_ww_pred.
- rewrite <- Zmod_unique with (q := 1) (r := -wwB + 2 * [[WW w4 w5]]);
-  auto with zarith.
- intros Hz1; rewrite Zmod_small; auto with zarith.
+ rewrite <- Zmod_unique with (q := 1) (r := -wwB + 2 * [[WW w4 w5]]).
+  3: zarith.
+ intros Hz1; rewrite Zmod_small.
  match type of H5 with -?X + ?Y = ?Z =>
-  assert (V: Y = Z + X);
-  try (rewrite <- H5; ring)
+  assert (V: Y = Z + X) by
+  (rewrite <- H5; ring)
  end.
  split.
  unfold zn2z_to_Z; rewrite <- Hw1.
@@ -823,59 +817,58 @@ intros x; case x; simpl ww_is_even.
  unfold ww_to_Z; simpl zn2z_to_Z.
  repeat rewrite Zsquare_mult; ring.
  rewrite Hz1.
- destruct (spec_ww_to_Z w_digits w_to_Z spec_to_Z z);auto with zarith.
+ destruct (spec_ww_to_Z w_digits w_to_Z spec_to_Z z);zarith.
  assert (V1 := spec_ww_to_Z w_digits w_to_Z spec_to_Z (WW w4 w5)).
- assert (0 <  [[WW w4 w5]]); auto with zarith.
- apply Z.lt_le_trans with (wB/ 2 * wB + 0); auto with zarith.
- autorewrite with rm10; apply Z.mul_pos_pos; auto with zarith.
- apply Z.mul_lt_mono_pos_r with 2; auto with zarith.
+ enough (0 <  [[WW w4 w5]]) by zarith.
+ apply Z.lt_le_trans with (wB/ 2 * wB + 0).
+ autorewrite with rm10; apply Z.mul_pos_pos.
+ apply Z.mul_lt_mono_pos_r with 2. zarith.
  autorewrite with rm10.
- rewrite Z.mul_comm; rewrite wB_div_2; auto with zarith.
- case (spec_to_Z w5);auto with zarith.
- case (spec_to_Z w5);auto with zarith.
+ rewrite Z.mul_comm; rewrite wB_div_2.
+ case (spec_to_Z w5);zarith.
+ case (spec_to_Z w5);zarith.
  simpl.
- assert (V2 := spec_to_Z w5);auto with zarith.
- assert (V1 := spec_ww_to_Z w_digits w_to_Z spec_to_Z (WW w4 w5)); auto with zarith.
- split; auto with zarith.
- assert (wwB <= 2 * [[WW w4 w5]]); auto with zarith.
+ assert (V2 := spec_to_Z w5); zarith.
+ assert (V1 := spec_ww_to_Z w_digits w_to_Z spec_to_Z (WW w4 w5)).
+ split. 2: zarith.
+ enough (wwB <= 2 * [[WW w4 w5]]) by zarith.
  apply Z.le_trans with (2 * ([|w4|] * wB)).
  rewrite wwB_wBwB; rewrite Z.pow_2_r.
- rewrite Z.mul_assoc; apply Z.mul_le_mono_nonneg_r; auto with zarith.
- assert (V2 := spec_to_Z w5);auto with zarith.
- rewrite <- wB_div_2; auto with zarith.
- simpl ww_to_Z; assert (V2 := spec_to_Z w5);auto with zarith.
- assert (V1 := spec_ww_to_Z w_digits w_to_Z spec_to_Z (WW w4 w5)); auto with zarith.
+ rewrite Z.mul_assoc. apply Z.mul_le_mono_nonneg_r.
+ assert (V2 := spec_to_Z w5);zarith.
+ rewrite <- wB_div_2; zarith.
+ simpl ww_to_Z; assert (V2 := spec_to_Z w5);zarith.
+ assert (V1 := spec_ww_to_Z w_digits w_to_Z spec_to_Z (WW w4 w5)).
  intros z1; change [-[C1 z1]] with (-wwB + [[z1]]).
  match goal with |- context[([+[C0 ?z]])] =>
    change [+[C0 z]] with ([[z]])
  end.
- rewrite spec_ww_add; auto with zarith.
- rewrite spec_ww_pred; auto with zarith.
+ rewrite spec_ww_add by zarith.
+ rewrite spec_ww_pred by zarith.
  rewrite ww_add_mult_mult_2.
  rename V1 into VV1.
- assert (VV2: 0 <  [[WW w4 w5]]); auto with zarith.
- apply Z.lt_le_trans with (wB/ 2 * wB + 0); auto with zarith.
- autorewrite with rm10; apply Z.mul_pos_pos; auto with zarith.
- apply Z.mul_lt_mono_pos_r with 2; auto with zarith.
+ assert (VV2: 0 <  [[WW w4 w5]]).
+ apply Z.lt_le_trans with (wB/ 2 * wB + 0).
+ autorewrite with rm10; apply Z.mul_pos_pos.
+ apply Z.mul_lt_mono_pos_r with 2. zarith.
  autorewrite with rm10.
- rewrite Z.mul_comm; rewrite wB_div_2; auto with zarith.
- assert (VV3 := spec_to_Z w5);auto with zarith.
- assert (VV3 := spec_to_Z w5);auto with zarith.
+ rewrite Z.mul_comm, wB_div_2.
+ assert (VV3 := spec_to_Z w5);zarith.
+ assert (VV3 := spec_to_Z w5);zarith.
  simpl.
- assert (VV3 := spec_to_Z w5);auto with zarith.
- assert (VV3: wwB <= 2 * [[WW w4 w5]]); auto with zarith.
+ assert (VV3 := spec_to_Z w5);zarith.
+ assert (VV3: wwB <= 2 * [[WW w4 w5]]).
  apply Z.le_trans with (2 * ([|w4|] * wB)).
  rewrite wwB_wBwB; rewrite Z.pow_2_r.
- rewrite Z.mul_assoc; apply Z.mul_le_mono_nonneg_r; auto with zarith.
- case (spec_to_Z w5);auto with zarith.
- rewrite <- wB_div_2; auto with zarith.
- simpl ww_to_Z; assert (V4 := spec_to_Z w5);auto with zarith.
- rewrite <- Zmod_unique with (q := 1) (r := -wwB + 2 * [[WW w4 w5]]);
-  auto with zarith.
- intros Hz1; rewrite Zmod_small; auto with zarith.
+ rewrite Z.mul_assoc; apply Z.mul_le_mono_nonneg_r.
+ case (spec_to_Z w5);zarith.
+ rewrite <- wB_div_2; zarith.
+ simpl ww_to_Z; assert (V4 := spec_to_Z w5);zarith.
+ rewrite <- Zmod_unique with (q := 1) (r := -wwB + 2 * [[WW w4 w5]]) by zarith.
+ intros Hz1; rewrite Zmod_small by zarith.
  match type of H5 with -?X + ?Y = ?Z =>
-  assert (V: Y = Z + X);
-  try (rewrite <- H5; ring)
+  assert (V: Y = Z + X) by
+  (rewrite <- H5; ring)
  end.
  match type of Hz1 with -?X + ?Y = -?X + ?Z - 1 =>
   assert (V1: Y = Z - 1);
@@ -883,8 +876,8 @@ intros x; case x; simpl ww_is_even.
     [rewrite <- Hz1 | idtac]; ring
     | idtac]
  end.
- rewrite <- Zmod_unique with (q := 1) (r := -wwB + [[z1]] + [[z]]);
-  auto with zarith.
+ rewrite <- Zmod_unique with (q := 1) (r := -wwB + [[z1]] + [[z]]).
+  3: zarith.
  unfold zn2z_to_Z; rewrite <- Hw1.
  unfold ww_to_Z, zn2z_to_Z in H1; rewrite H1.
  rewrite <- Hw0.
@@ -899,26 +892,26 @@ intros x; case x; simpl ww_is_even.
  rewrite Hz1.
  unfold ww_to_Z; simpl zn2z_to_Z.
  repeat rewrite Zsquare_mult; ring.
- assert (V2 := spec_ww_to_Z w_digits w_to_Z spec_to_Z z);auto with zarith.
- assert (V2 := spec_ww_to_Z w_digits w_to_Z spec_to_Z z);auto with zarith.
- assert (V3 := spec_ww_to_Z w_digits w_to_Z spec_to_Z z1);auto with zarith.
- split; auto with zarith.
+ assert (V2 := spec_ww_to_Z w_digits w_to_Z spec_to_Z z);zarith.
+ assert (V2 := spec_ww_to_Z w_digits w_to_Z spec_to_Z z).
+ assert (V3 := spec_ww_to_Z w_digits w_to_Z spec_to_Z z1).
+ split. 2: zarith.
  rewrite (Z.add_comm (-wwB)); rewrite <- Z.add_assoc.
  rewrite H5.
  match goal with |- 0 <= ?X + (?Y - ?Z)  =>
-  apply Z.le_trans with (X - Z); auto with zarith
+  apply Z.le_trans with (X - Z)
  end.
- 2: generalize (spec_ww_to_Z w_digits w_to_Z spec_to_Z (WW w6 w1)); unfold ww_to_Z; auto with zarith.
+ 2: generalize (spec_ww_to_Z w_digits w_to_Z spec_to_Z (WW w6 w1)); unfold ww_to_Z; zarith.
  rewrite V1.
  match goal with |- 0 <= ?X - 1 - ?Y =>
-   assert (Y < X); auto with zarith
+   enough (Y < X) by zarith
  end.
- apply Z.lt_le_trans with wwB; auto with zarith.
- intros (H3, H4).
+ apply Z.lt_le_trans with wwB; zarith.
+ + intros (H3, H4).
  match goal with |- context [ww_sub_c ?y ?z] =>
   generalize (spec_ww_sub_c y z); case (ww_sub_c y z)
  end.
- intros z; change [-[C0 z]] with ([[z]]).
+ * intros z; change [-[C0 z]] with ([[z]]).
  match goal with |- context[([+[C1 ?z]])] =>
    replace [+[C1 z]] with (wwB + [[z]])
  end.
@@ -945,27 +938,24 @@ intros x; case x; simpl ww_is_even.
  simpl ww_to_Z.
  rewrite wwB_wBwB; rewrite Z.pow_2_r.
  match goal with |- ?X * ?Y + (?Z * ?Y + ?T - ?U) <= _ =>
-  apply Z.le_trans with (X * Y + (Z * Y + T - 0));
-  auto with zarith
+  apply Z.le_trans with (X * Y + (Z * Y + T - 0))
  end.
  assert (V := Zsquare_pos [|w5|]);
- rewrite Zsquare_mult in V; auto with zarith.
+ rewrite Zsquare_mult in V; zarith.
  autorewrite with rm10.
  match goal with |- _ <= 2 * (?U * ?V + ?W) =>
-  apply Z.le_trans with (2 * U * V + 0);
-  auto with zarith
+  apply Z.le_trans with (2 * U * V + 0)
  end.
  match goal with |- ?X * ?Y + (?Z * ?Y + ?T) <= _ =>
-  replace (X * Y + (Z * Y + T)) with ((X + Z) * Y + T);
-  try ring
+  replace (X * Y + (Z * Y + T)) with ((X + Z) * Y + T)
+  by ring
  end.
- apply Z.lt_le_incl; apply beta_lex_inv; auto with zarith.
- destruct (spec_to_Z w1);auto with zarith.
- destruct (spec_to_Z w5);auto with zarith.
- rewrite Z.mul_add_distr_l; auto with zarith.
- rewrite Z.mul_assoc; auto with zarith.
- intros z; replace [-[C1 z]] with (- wwB + [[z]]).
- 2: simpl; case wwB; auto with zarith.
+ apply Z.lt_le_incl; apply beta_lex_inv.
+ lia. zarith.
+ destruct (spec_to_Z w1); lia.
+ destruct (spec_to_Z w5); lia.
+ * intros z; replace [-[C1 z]] with (- wwB + [[z]]).
+ 2: simpl; case wwB; zarith.
  intros H5; rewrite spec_w_square_c in H5;
   auto.
  match goal with |- context[([+[C0 ?z]])] =>
@@ -995,67 +985,63 @@ intros x; case x; simpl ww_is_even.
  simpl ww_to_Z.
  rewrite wwB_wBwB; rewrite Z.pow_2_r.
  match goal with |- (?Z * ?Y + ?T - ?U) + ?X * ?Y <= _ =>
-  apply Z.le_trans with ((Z * Y + T - 0) + X * Y);
-  auto with zarith
+  apply Z.le_trans with ((Z * Y + T - 0) + X * Y)
  end.
  assert (V1 := Zsquare_pos [|w5|]);
- rewrite Zsquare_mult in V1; auto with zarith.
+ rewrite Zsquare_mult in V1; zarith.
  autorewrite with rm10.
  match goal with |- _ <= 2 * (?U * ?V + ?W) =>
-  apply Z.le_trans with (2 * U * V + 0);
-  auto with zarith
+  apply Z.le_trans with (2 * U * V + 0)
  end.
  match goal with |- (?Z * ?Y + ?T) + ?X * ?Y  <= _ =>
-  replace ((Z * Y + T) + X * Y) with ((X + Z) * Y + T);
-  try ring
+  replace ((Z * Y + T) + X * Y) with ((X + Z) * Y + T)
+  by ring
  end.
- apply Z.lt_le_incl; apply beta_lex_inv; auto with zarith.
- destruct (spec_to_Z w1);auto with zarith.
- destruct (spec_to_Z w5);auto with zarith.
- rewrite Z.mul_add_distr_l; auto with zarith.
- rewrite Z.mul_assoc; auto with zarith.
- Z.le_elim H2.
- intros c1 (H3, H4).
+ apply Z.lt_le_incl; apply beta_lex_inv.
+ lia. zarith.
+ destruct (spec_to_Z w1); lia.
+ destruct (spec_to_Z w5); lia.
+ - Z.le_elim H2.
+ + intros c1 (H3, H4).
  match type of H3 with ?X = ?Y => absurd (X < Y) end.
- apply Z.le_ngt; rewrite <- H3; auto with zarith.
- rewrite Z.mul_add_distr_r.
- apply Z.lt_le_trans with ((2 * [|w4|]) * wB + 0);
-  auto with zarith.
- apply beta_lex_inv; auto with zarith.
- destruct (spec_to_Z w0);auto with zarith.
- assert (V1 := spec_to_Z w5);auto with zarith.
- rewrite (Z.mul_comm wB); auto with zarith.
- assert (0 <= [|w5|] * (2 * [|w4|])); auto with zarith.
- intros c1 (H3, H4); rewrite H2 in H3.
+ * apply Z.le_ngt; rewrite <- H3; zarith.
+ * rewrite Z.mul_add_distr_r.
+ apply Z.lt_le_trans with ((2 * [|w4|]) * wB + 0).
+ apply beta_lex_inv. 1-2: zarith.
+ destruct (spec_to_Z w0);zarith.
+ assert (V1 := spec_to_Z w5).
+ rewrite (Z.mul_comm wB) by zarith.
+ assert (0 <= [|w5|] * (2 * [|w4|])); zarith.
+ + intros c1 (H3, H4); rewrite H2 in H3.
  match type of H3 with ?X + ?Y = (?Z + ?T) * ?U + ?V =>
   assert (VV: (Y = (T * U) + V));
   [replace Y with ((X + Y) - X);
     [rewrite H3; ring | ring] | idtac]
  end.
- assert (V1 := spec_to_Z w0);auto with zarith.
- assert (V2 := spec_to_Z w5);auto with zarith.
+ assert (V1 := spec_to_Z w0).
+ assert (V2 := spec_to_Z w5).
  case V2; intros V3 _.
- Z.le_elim V3; auto with zarith.
- match type of VV with ?X = ?Y => absurd (X < Y) end.
- apply Z.le_ngt; rewrite <- VV; auto with zarith.
- apply Z.lt_le_trans with wB; auto with zarith.
+ Z.le_elim V3.
+ * match type of VV with ?X = ?Y => absurd (X < Y) end.
+ apply Z.le_ngt; rewrite <- VV; zarith.
+ apply Z.lt_le_trans with wB. zarith.
  match goal with |- _ <= ?X + _ =>
-  apply Z.le_trans with X; auto with zarith
+  apply Z.le_trans with X; [ | zarith ]
  end.
  match goal with |- _ <= _ * ?X =>
-  apply Z.le_trans with (1 * X); auto with zarith
+  apply Z.le_trans with (1 * X); [ | zarith ]
  end.
  autorewrite with rm10.
- rewrite <- wB_div_2; apply Z.mul_le_mono_nonneg_l; auto with zarith.
- rewrite <- V3 in VV; generalize VV; autorewrite with rm10;
+ rewrite <- wB_div_2; apply Z.mul_le_mono_nonneg_l; zarith.
+ * rewrite <- V3 in VV; generalize VV; autorewrite with rm10;
  clear VV; intros VV.
- rewrite spec_ww_add_c; auto with zarith.
+ rewrite spec_ww_add_c by zarith.
  rewrite ww_add_mult_mult_2_plus_1.
  match goal with |- context[?X mod wwB] =>
    rewrite <- Zmod_unique with (q := 1) (r := -wwB + X)
- end; auto with zarith.
+ end. 3: zarith.
  simpl ww_to_Z.
- rewrite spec_w_Bm1; auto with zarith.
+ rewrite spec_w_Bm1 by zarith.
  split.
  change ([||WW x y||]) with ([[x]] * wwB + [[y]]).
  rewrite <- Hw1.
@@ -1069,45 +1055,45 @@ intros x; case x; simpl ww_is_even.
  rewrite H2.
  rewrite wwB_wBwB.
  repeat rewrite Zsquare_mult; ring.
- assert (V4 := spec_ww_to_Z w_digits w_to_Z spec_to_Z y);auto with zarith.
- assert (V4 := spec_ww_to_Z w_digits w_to_Z spec_to_Z y);auto with zarith.
+ assert (V4 := spec_ww_to_Z w_digits w_to_Z spec_to_Z y);zarith.
+ assert (V4 := spec_ww_to_Z w_digits w_to_Z spec_to_Z y).
  simpl ww_to_Z; unfold ww_to_Z.
- rewrite spec_w_Bm1; auto with zarith.
+ rewrite spec_w_Bm1 by zarith.
  split.
  rewrite wwB_wBwB; rewrite Z.pow_2_r.
  match goal with |- _ <= -?X + (2 * (?Z * ?T + ?U) + ?V) =>
-  assert (X <= 2 * Z * T); auto with zarith
+  assert (X <= 2 * Z * T)
  end.
- apply Z.mul_le_mono_nonneg_r; auto with zarith.
- rewrite <- wB_div_2; apply Z.mul_le_mono_nonneg_l; auto with zarith.
- rewrite Z.mul_add_distr_l; auto with zarith.
- rewrite Z.mul_assoc; auto with zarith.
+ apply Z.mul_le_mono_nonneg_r. zarith.
+ rewrite <- wB_div_2; apply Z.mul_le_mono_nonneg_l; zarith.
+ rewrite Z.mul_add_distr_l by zarith.
+ rewrite Z.mul_assoc; zarith.
  match goal with |- _ + ?X  < _ =>
-  replace X with ((2 * (([|w4|]) + 1) * wB) - 1); try ring
+  replace X with ((2 * (([|w4|]) + 1) * wB) - 1) by ring
  end.
- assert (2 * ([|w4|] + 1) * wB <= 2 * wwB); auto with zarith.
- rewrite <- Z.mul_assoc; apply Z.mul_le_mono_nonneg_l; auto with zarith.
+ enough (2 * ([|w4|] + 1) * wB <= 2 * wwB) by zarith.
+ rewrite <- Z.mul_assoc; apply Z.mul_le_mono_nonneg_l. zarith.
  rewrite wwB_wBwB; rewrite Z.pow_2_r.
- apply Z.mul_le_mono_nonneg_r; auto with zarith.
- case (spec_to_Z w4);auto with zarith.
+ apply Z.mul_le_mono_nonneg_r. zarith.
+ case (spec_to_Z w4);zarith.
 Qed.
 
  Lemma spec_ww_is_zero: forall x,
    if ww_is_zero x then [[x]] = 0 else 0 < [[x]].
   intro x; unfold ww_is_zero.
-  rewrite spec_ww_compare. case Z.compare_spec;
-   auto with zarith.
+  rewrite spec_ww_compare. case Z.compare_spec.
+   1-2: zarith.
   simpl ww_to_Z.
-  assert (V4 := spec_ww_to_Z w_digits w_to_Z spec_to_Z x);auto with zarith.
+  assert (V4 := spec_ww_to_Z w_digits w_to_Z spec_to_Z x);zarith.
   Qed.
 
   Lemma wwB_4_2: 2 * (wwB / 4) = wwB/ 2.
   pattern wwB at 1; rewrite wwB_wBwB; rewrite Z.pow_2_r.
   rewrite <- wB_div_2.
   match goal with |- context[(2 * ?X) * (2 * ?Z)] =>
-    replace ((2 * X) * (2 * Z)) with ((X * Z) * 4); try ring
+    replace ((2 * X) * (2 * Z)) with ((X * Z) * 4) by ring
   end.
-  rewrite Z_div_mult; auto with zarith.
+  rewrite Z_div_mult by zarith.
   rewrite Z.mul_assoc; rewrite wB_div_2.
   rewrite wwB_div_2; ring.
   Qed.
@@ -1123,153 +1109,154 @@ Qed.
     intros HH H1; rewrite HH; split; auto.
   intros H2.
   generalize (spec_ww_head0 x H2); case (ww_head0 x);  autorewrite with rm10.
-  intros (H3, H4); split; auto with zarith.
+  intros (H3, H4); split. 2: zarith.
   apply Z.le_trans with (2 := H3).
-  apply Zdiv_le_compat_l; auto with zarith.
-  intros xh xl (H3, H4); split; auto with zarith.
+  apply Zdiv_le_compat_l; zarith.
+  intros xh xl (H3, H4); split. 2: zarith.
   apply Z.le_trans with (2 := H3).
-  apply Zdiv_le_compat_l; auto with zarith.
+  apply Zdiv_le_compat_l; zarith.
   intros H1.
   case (spec_to_w_Z (ww_head0 x)); intros Hv1 Hv2.
   assert (Hp0: 0 < [[ww_head0 x]]).
     generalize (spec_ww_is_even (ww_head0 x)); rewrite H1.
     generalize Hv1; case [[ww_head0 x]].
-    rewrite Zmod_small; auto with zarith.
-    intros; assert (0 < Zpos p); auto with zarith.
+    rewrite Zmod_small; zarith.
+    intros; assert (0 < Zpos p); zarith.
     red; simpl; auto.
     intros p H2; case H2; auto.
   assert (Hp: [[ww_pred (ww_head0 x)]] = [[ww_head0 x]] - 1).
     rewrite spec_ww_pred.
-    rewrite Zmod_small; auto with zarith.
+    rewrite Zmod_small; zarith.
   intros H2; split.
     generalize (spec_ww_is_even (ww_pred (ww_head0 x)));
       case ww_is_even; auto.
     rewrite Hp.
-    rewrite Zminus_mod; auto with zarith.
-    rewrite H2; repeat rewrite Zmod_small; auto with zarith.
+    rewrite Zminus_mod by zarith.
+    rewrite H2; repeat rewrite Zmod_small; zarith.
   intros H3; rewrite Hp.
   case (spec_ww_head0 x); auto; intros Hv3 Hv4.
   assert (Hu: forall u, 0 < u -> 2 *  2 ^ (u - 1) = 2 ^u).
     intros u Hu.
     pattern 2 at 1; rewrite <- Z.pow_1_r.
-    rewrite <- Zpower_exp; auto with zarith.
-    ring_simplify (1 + (u - 1)); auto with zarith.
-  split; auto with zarith.
-  apply Z.mul_le_mono_pos_r with 2; auto with zarith.
+    rewrite <- Zpower_exp by zarith.
+    ring_simplify (1 + (u - 1)); zarith.
+  split.
+  apply Z.mul_le_mono_pos_r with 2. zarith.
   repeat rewrite (fun x => Z.mul_comm x 2).
   rewrite wwB_4_2.
-  rewrite Z.mul_assoc; rewrite Hu; auto with zarith.
-  apply Z.le_lt_trans with (2 * 2 ^ ([[ww_head0 x]] - 1) * [[x]]); auto with zarith;
-    rewrite Hu; auto with zarith.
-  apply Z.mul_le_mono_nonneg_r; auto with zarith.
-  apply Zpower_le_monotone; auto with zarith.
+  rewrite Z.mul_assoc; rewrite Hu; zarith.
+  apply Z.le_lt_trans with (2 * 2 ^ ([[ww_head0 x]] - 1) * [[x]]);
+    rewrite Hu.
+  2-4: zarith.
+  apply Z.mul_le_mono_nonneg_r. zarith.
+  apply Zpower_le_monotone; zarith.
   Qed.
 
   Theorem wwB_4_wB_4: wwB / 4 = wB / 4 * wB.
   Proof.
-  symmetry; apply Zdiv_unique with 0; auto with zarith.
-  rewrite Z.mul_assoc; rewrite wB_div_4; auto with zarith.
+  symmetry; apply Zdiv_unique with 0. zarith.
+  rewrite Z.mul_assoc; rewrite wB_div_4.
   rewrite wwB_wBwB; ring.
   Qed.
 
   Lemma spec_ww_sqrt : forall x,
        [[ww_sqrt x]] ^ 2 <= [[x]] < ([[ww_sqrt x]] + 1) ^ 2.
+  clear spec_w_Bm1.
+  assert (fake_use := (w_1, w_Bm1)); clear fake_use.
   assert (U := wB_pos w_digits).
   intro x; unfold ww_sqrt.
   generalize (spec_ww_is_zero x); case (ww_is_zero x).
   simpl ww_to_Z; simpl Z.pow; unfold Z.pow_pos; simpl;
-    auto with zarith.
+    zarith.
   intros H1.
   rewrite spec_ww_compare. case Z.compare_spec;
     simpl ww_to_Z; autorewrite with rm10.
   generalize H1; case x.
-  intros HH; contradict HH; simpl ww_to_Z; auto with zarith.
+  intros HH; contradict HH; simpl ww_to_Z; zarith.
   intros w0 w1; simpl ww_to_Z; autorewrite with w_rewrite rm10.
   intros H2; case (spec_ww_head1 (WW w0 w1)); intros H3 H4 H5.
   generalize (H4 H2); clear H4; rewrite H5; clear H5; autorewrite with rm10.
   intros (H4, H5).
-  assert (V: wB/4 <= [|w0|]).
-  apply beta_lex with 0 [|w1|] wB; auto with zarith; autorewrite with rm10.
-  rewrite <- wwB_4_wB_4; auto.
-  generalize (@spec_w_sqrt2 w0 w1 V);auto with zarith.
+  assert (V: wB/4 <= [|w0|]). {
+  apply beta_lex with 0 [|w1|] wB. 2-3: zarith. autorewrite with rm10.
+  rewrite <- wwB_4_wB_4; auto. }
+  generalize (@spec_w_sqrt2 w0 w1 V).
   case (w_sqrt2 w0 w1); intros w2 c.
   simpl ww_to_Z; simpl @fst.
   case c; unfold interp_carry; autorewrite with rm10.
   intros w3 (H6, H7); rewrite H6.
-  assert (V1 := spec_to_Z w3);auto with zarith.
-  split; auto with zarith.
-  apply Z.le_lt_trans with ([|w2|] ^2  + 2 * [|w2|]); auto with zarith.
+  assert (V1 := spec_to_Z w3).
+  split. zarith.
+  apply Z.le_lt_trans with ([|w2|] ^2  + 2 * [|w2|]). zarith.
   match goal with |- ?X < ?Z =>
-    replace Z with (X + 1); auto with zarith
+    replace Z with (X + 1); lia
   end.
-  repeat rewrite Zsquare_mult; ring.
   intros w3 (H6, H7); rewrite H6.
-  assert (V1 := spec_to_Z w3);auto with zarith.
-  split; auto with zarith.
-  apply Z.le_lt_trans with ([|w2|] ^2  + 2 * [|w2|]); auto with zarith.
+  assert (V1 := spec_to_Z w3).
+  split. zarith.
+  apply Z.le_lt_trans with ([|w2|] ^2  + 2 * [|w2|]). zarith.
   match goal with |- ?X < ?Z =>
-    replace Z with (X + 1); auto with zarith
+    replace Z with (X + 1); lia
   end.
-  repeat rewrite Zsquare_mult; ring.
-  intros HH; case (spec_to_w_Z (ww_head1 x)); auto with zarith.
+  intros HH; case (spec_to_w_Z (ww_head1 x)); zarith.
   intros Hv1.
   case (spec_ww_head1 x); intros Hp1 Hp2.
   generalize (Hp2 H1); clear Hp2; intros Hp2.
   assert (Hv2: [[ww_head1 x]] <= Zpos (xO w_digits)).
-    case (Z.le_gt_cases (Zpos (xO w_digits)) [[ww_head1 x]]); auto with zarith; intros HH1.
+    case (Z.le_gt_cases (Zpos (xO w_digits)) [[ww_head1 x]]). 2: zarith. intros HH1.
     case Hp2; intros _ HH2; contradict HH2.
     apply Z.le_ngt; unfold base.
     apply Z.le_trans with (2 ^ [[ww_head1 x]]).
-      apply Zpower_le_monotone; auto with zarith.
+      apply Zpower_le_monotone; zarith.
     pattern (2 ^ [[ww_head1 x]]) at 1;
       rewrite <- (Z.mul_1_r (2 ^ [[ww_head1 x]])).
-    apply Z.mul_le_mono_nonneg_l; auto with zarith.
+    apply Z.mul_le_mono_nonneg_l; zarith.
   generalize (spec_ww_add_mul_div x W0 (ww_head1 x) Hv2);
      case ww_add_mul_div.
   simpl ww_to_Z; autorewrite with w_rewrite rm10.
-  rewrite Zmod_small; auto with zarith.
+  rewrite Zmod_small.
   intros H2. symmetry in H2. rewrite Z.mul_eq_0 in H2. destruct H2 as [H2|H2].
-  rewrite H2; unfold Z.pow, Z.pow_pos; simpl; auto with zarith.
+  rewrite H2; unfold Z.pow, Z.pow_pos; simpl; zarith.
   match type of H2 with ?X = ?Y =>
-   absurd (Y < X); try (rewrite H2; auto with zarith; fail)
+   absurd (Y < X); [ rewrite H2; zarith | ]
   end.
-  apply Z.pow_pos_nonneg; auto with zarith.
-  split; auto with zarith.
+  apply Z.pow_pos_nonneg; zarith.
+  split. zarith.
   case Hp2; intros _ tmp; apply Z.le_lt_trans with (2 := tmp);
    clear tmp.
-  rewrite Z.mul_comm; apply Z.mul_le_mono_nonneg_r; auto with zarith.
+  rewrite Z.mul_comm; apply Z.mul_le_mono_nonneg_r; zarith.
   assert (Hv0: [[ww_head1 x]] = 2 * ([[ww_head1 x]]/2)).
-    pattern [[ww_head1 x]] at 1; rewrite (Z_div_mod_eq [[ww_head1 x]] 2);
-      auto with zarith.
+    pattern [[ww_head1 x]] at 1; rewrite (Z_div_mod_eq [[ww_head1 x]] 2) by
+      zarith.
     generalize (spec_ww_is_even (ww_head1 x)); rewrite Hp1;
       intros tmp; rewrite tmp; rewrite Z.add_0_r; auto.
   intros w0 w1; autorewrite with w_rewrite rm10.
-  rewrite Zmod_small; auto with zarith.
-  2: rewrite Z.mul_comm; auto with zarith.
+  rewrite Zmod_small
+  by (rewrite Z.mul_comm; zarith).
   intros H2.
-  assert (V: wB/4 <= [|w0|]).
-  apply beta_lex with 0 [|w1|] wB; auto with zarith; autorewrite with rm10.
+  assert (V: wB/4 <= [|w0|]). {
+  apply beta_lex with 0 [|w1|] wB. 2: zarith. autorewrite with rm10.
   simpl ww_to_Z in H2; rewrite H2.
-  rewrite <- wwB_4_wB_4; auto with zarith.
-  rewrite Z.mul_comm; auto with zarith.
-  assert (V1 := spec_to_Z w1);auto with zarith.
-  generalize (@spec_w_sqrt2 w0 w1 V);auto with zarith.
+  rewrite <- wwB_4_wB_4 by zarith.
+  rewrite Z.mul_comm; zarith.
+  assert (V1 := spec_to_Z w1);zarith. }
+  generalize (@spec_w_sqrt2 w0 w1 V).
   case (w_sqrt2 w0 w1); intros w2 c.
   case (spec_to_Z w2); intros HH1 HH2.
   simpl ww_to_Z; simpl @fst.
   assert (Hv3: [[ww_pred ww_zdigits]]
-                 = Zpos (xO w_digits) - 1).
+                 = Zpos (xO w_digits) - 1). {
     rewrite spec_ww_pred; rewrite spec_ww_zdigits.
-    rewrite Zmod_small; auto with zarith.
-    split; auto with zarith.
-    apply Z.lt_le_trans with (Zpos (xO w_digits)); auto with zarith.
-    unfold base; apply Zpower2_le_lin; auto with zarith.
+    rewrite Zmod_small. reflexivity.
+    split. zarith.
+    apply Z.lt_le_trans with (Zpos (xO w_digits)). zarith.
+    unfold base; apply Zpower2_le_lin; zarith. }
   assert (Hv4: [[ww_head1 x]]/2 < wB).
     apply Z.le_lt_trans with (Zpos w_digits).
-    apply Z.mul_le_mono_pos_r with 2; auto with zarith.
+    apply Z.mul_le_mono_pos_r with 2. zarith.
     repeat rewrite (fun x => Z.mul_comm x 2).
     rewrite <- Hv0;  rewrite <- Pos2Z.inj_xO; auto.
-    unfold base; apply Zpower2_lt_lin; auto with zarith.
+    unfold base; apply Zpower2_lt_lin; zarith.
   assert (Hv5: [[(ww_add_mul_div (ww_pred ww_zdigits) W0 (ww_head1 x))]]
                  = [[ww_head1 x]]/2).
     rewrite spec_ww_add_mul_div.
@@ -1277,93 +1264,92 @@ Qed.
     rewrite Hv3.
     ring_simplify (Zpos (xO w_digits) - (Zpos (xO w_digits) - 1)).
     rewrite Z.pow_1_r.
-    rewrite Zmod_small; auto with zarith.
-    split; auto with zarith.
-    apply Z.lt_le_trans with (1 := Hv4); auto with zarith.
-    unfold base; apply Zpower_le_monotone; auto with zarith.
-    split; unfold ww_digits; try rewrite Pos2Z.inj_xO; auto with zarith.
-    rewrite Hv3; auto with zarith.
+    rewrite Zmod_small.
+    reflexivity.
+    split. zarith.
+    apply Z.lt_le_trans with (1 := Hv4). 2: zarith.
+    unfold base; apply Zpower_le_monotone. zarith.
+    split; unfold ww_digits; try rewrite Pos2Z.inj_xO; zarith.
   assert (Hv6: [|low(ww_add_mul_div (ww_pred ww_zdigits) W0 (ww_head1 x))|]
                  = [[ww_head1 x]]/2).
     rewrite spec_low.
-    rewrite Hv5; rewrite Zmod_small; auto with zarith.
-  rewrite spec_w_add_mul_div; auto with zarith.
-  rewrite spec_w_sub; auto with zarith.
+    rewrite Hv5; rewrite Zmod_small; zarith.
+  rewrite spec_w_add_mul_div.
+  rewrite spec_w_sub.
   rewrite spec_w_0.
   simpl ww_to_Z; autorewrite with rm10.
   rewrite Hv6; rewrite spec_w_zdigits.
   rewrite (fun x y => Zmod_small (x - y)).
   ring_simplify (Zpos w_digits - (Zpos w_digits - [[ww_head1 x]] / 2)).
   rewrite Zmod_small.
-  simpl ww_to_Z in H2; rewrite H2; auto with zarith.
+  simpl ww_to_Z in H2; rewrite H2.
   intros (H4, H5); split.
-  apply Z.mul_le_mono_pos_r with (2 ^ [[ww_head1 x]]); auto with zarith.
+  apply Z.mul_le_mono_pos_r with (2 ^ [[ww_head1 x]]). zarith.
   rewrite H4.
-  apply Z.le_trans with ([|w2|] ^ 2); auto with zarith.
+  apply Z.le_trans with ([|w2|] ^ 2).
   rewrite Z.mul_comm.
   pattern [[ww_head1 x]] at 1;
-    rewrite Hv0; auto with zarith.
-  rewrite (Z.mul_comm 2); rewrite Z.pow_mul_r;
-    auto with zarith.
+    rewrite Hv0.
+  rewrite (Z.mul_comm 2); rewrite Z.pow_mul_r by
+    zarith.
   assert (tmp: forall p q, p ^ 2 * q ^ 2 = (p * q) ^2);
    try (intros; repeat rewrite Zsquare_mult; ring);
    rewrite tmp; clear tmp.
-  apply Zpower_le_monotone3; auto with zarith.
-  split; auto with zarith.
+  apply Zpower_le_monotone3. zarith.
+  split. zarith.
   pattern [|w2|] at 2;
-     rewrite (Z_div_mod_eq [|w2|] (2 ^ ([[ww_head1 x]] / 2)));
-     auto with zarith.
+     rewrite (Z_div_mod_eq [|w2|] (2 ^ ([[ww_head1 x]] / 2))) by
+     zarith.
   match goal with |- ?X <= ?X + ?Y =>
-    assert (0 <= Y); auto with zarith
+    enough (0 <= Y) by zarith
   end.
-  case (Z_mod_lt [|w2|] (2 ^ ([[ww_head1 x]] / 2))); auto with zarith.
+  case (Z_mod_lt [|w2|] (2 ^ ([[ww_head1 x]] / 2))); zarith.
   case c; unfold interp_carry; autorewrite with rm10;
-    intros w3; assert (V3 := spec_to_Z w3);auto with zarith.
-  apply Z.mul_lt_mono_pos_r with (2 ^ [[ww_head1 x]]); auto with zarith.
+    intros w3; assert (V3 := spec_to_Z w3);zarith.
+  apply Z.mul_lt_mono_pos_r with (2 ^ [[ww_head1 x]]). zarith.
   rewrite H4.
-  apply Z.le_lt_trans with ([|w2|] ^ 2 + 2 * [|w2|]); auto with zarith.
-  apply Z.lt_le_trans with (([|w2|] + 1) ^ 2); auto with zarith.
+  apply Z.le_lt_trans with ([|w2|] ^ 2 + 2 * [|w2|]). zarith.
+  apply Z.lt_le_trans with (([|w2|] + 1) ^ 2).
   match goal with |- ?X < ?Y =>
-    replace Y with (X + 1); auto with zarith
+    replace Y with (X + 1); [ zarith | ]
   end.
   repeat rewrite (Zsquare_mult); ring.
   rewrite Z.mul_comm.
   pattern [[ww_head1 x]] at 1; rewrite Hv0.
-  rewrite (Z.mul_comm 2); rewrite Z.pow_mul_r;
-   auto with zarith.
+  rewrite (Z.mul_comm 2); rewrite Z.pow_mul_r by
+   zarith.
   assert (tmp: forall p q, p ^ 2 * q ^ 2 = (p * q) ^2);
    try (intros; repeat rewrite Zsquare_mult; ring);
    rewrite tmp; clear tmp.
-  apply Zpower_le_monotone3; auto with zarith.
-  split; auto with zarith.
-  pattern [|w2|] at 1; rewrite (Z_div_mod_eq [|w2|] (2 ^ ([[ww_head1 x]]/2)));
-    auto with zarith.
+  apply Zpower_le_monotone3. zarith.
+  split. zarith.
+  pattern [|w2|] at 1; rewrite (Z_div_mod_eq [|w2|] (2 ^ ([[ww_head1 x]]/2))) by
+    zarith.
   rewrite <- Z.add_assoc; rewrite Z.mul_add_distr_l.
-  autorewrite with rm10; apply Z.add_le_mono_l; auto with zarith.
-  case (Z_mod_lt [|w2|] (2 ^ ([[ww_head1 x]]/2))); auto with zarith.
-  split; auto with zarith.
-  apply Z.le_lt_trans with ([|w2|]); auto with zarith.
-  apply Zdiv_le_upper_bound; auto with zarith.
-  pattern [|w2|] at 1; replace [|w2|] with ([|w2|] * 2 ^0);
-    auto with zarith.
-  apply Z.mul_le_mono_nonneg_l; auto with zarith.
-  apply Zpower_le_monotone; auto with zarith.
+  autorewrite with rm10; apply Z.add_le_mono_l.
+  case (Z_mod_lt [|w2|] (2 ^ ([[ww_head1 x]]/2))); zarith.
+  split. zarith.
+  apply Z.le_lt_trans with ([|w2|]). 2: zarith.
+  apply Zdiv_le_upper_bound. zarith.
+  pattern [|w2|] at 1; replace [|w2|] with ([|w2|] * 2 ^0).
+  apply Z.mul_le_mono_nonneg_l. zarith.
+  apply Zpower_le_monotone; zarith.
   rewrite Z.pow_0_r; autorewrite with rm10; auto.
-  split; auto with zarith.
-  rewrite Hv0 in Hv2; rewrite (Pos2Z.inj_xO w_digits) in Hv2; auto with zarith.
-  apply Z.le_lt_trans with (Zpos w_digits); auto with zarith.
-  unfold base; apply Zpower2_lt_lin; auto with zarith.
-  rewrite spec_w_sub; auto with zarith.
-  rewrite Hv6; rewrite spec_w_zdigits; auto with zarith.
-  assert (Hv7: 0 < [[ww_head1 x]]/2); auto with zarith.
-  rewrite Zmod_small; auto with zarith.
-  split; auto with zarith.
-  assert ([[ww_head1 x]]/2 <= Zpos w_digits); auto with zarith.
-  apply Z.mul_le_mono_pos_r with 2; auto with zarith.
+  split.
+  rewrite Hv0 in Hv2; rewrite (Pos2Z.inj_xO w_digits) in Hv2; zarith.
+  apply Z.le_lt_trans with (Zpos w_digits). zarith.
+  unfold base; apply Zpower2_lt_lin; zarith.
+  rewrite spec_w_sub by zarith.
+  rewrite Hv6; rewrite spec_w_zdigits by zarith.
+  assert (Hv7: 0 < [[ww_head1 x]]/2) by zarith.
+  rewrite Zmod_small. zarith.
+  split.
+  enough ([[ww_head1 x]]/2 <= Zpos w_digits) by zarith.
+  apply Z.mul_le_mono_pos_r with 2. zarith.
   repeat rewrite (fun x => Z.mul_comm x 2).
-  rewrite <- Hv0; rewrite <- Pos2Z.inj_xO; auto with zarith.
-  apply Z.le_lt_trans with (Zpos w_digits); auto with zarith.
-  unfold base; apply Zpower2_lt_lin; auto with zarith.
+  rewrite <- Hv0; rewrite <- Pos2Z.inj_xO; zarith.
+  apply Z.le_lt_trans with (Zpos w_digits). zarith.
+  unfold base; apply Zpower2_lt_lin; zarith.
   Qed.
 
 End DoubleSqrt.

--- a/SpecViaZ/NSigNAxioms.v
+++ b/SpecViaZ/NSigNAxioms.v
@@ -6,7 +6,7 @@
 (*         *       GNU Lesser General Public License Version 2.1        *)
 (************************************************************************)
 
-Require Import ZArith OrdersFacts Nnat NAxioms NSig.
+Require Import ZArith OrdersFacts Nnat NAxioms NSig Lia.
 
 (** * The interface [NSig.NType] implies the interface [NAxiomsSig] *)
 
@@ -22,7 +22,7 @@ Hint Rewrite
 Ltac nsimpl := autorewrite with nsimpl.
 Ltac ncongruence := unfold eq, to_N; repeat red; intros; nsimpl; congruence.
 Ltac zify := unfold eq, lt, le, to_N in *; nsimpl.
-Ltac omega_pos n := generalize (spec_pos n); omega with *.
+Ltac omega_pos n := generalize (spec_pos n); lia.
 
 Local Obligation Tactic := ncongruence.
 
@@ -112,7 +112,7 @@ Qed.
 
 Theorem sub_succ_r : forall n m, n - (succ m) == pred (n - m).
 Proof.
-intros. zify. omega with *.
+intros. zify. lia.
 Qed.
 
 Theorem mul_0_l : forall n, 0 * n == 0.
@@ -196,22 +196,22 @@ Qed.
 
 Theorem min_l : forall n m, n <= m -> min n m == n.
 Proof.
-intros n m. zify. omega with *.
+now intros n m; zify; lia.
 Qed.
 
 Theorem min_r : forall n m, m <= n -> min n m == m.
 Proof.
-intros n m. zify. omega with *.
+now intros n m; zify; lia.
 Qed.
 
 Theorem max_l : forall n m, m <= n -> max n m == n.
 Proof.
-intros n m. zify. omega with *.
+now intros n m; zify; lia.
 Qed.
 
 Theorem max_r : forall n m, n <= m -> max n m == m.
 Proof.
-intros n m. zify. omega with *.
+now intros n m; zify; lia.
 Qed.
 
 (** Properties specific to natural numbers, not integers. *)

--- a/SpecViaZ/ZSigZAxioms.v
+++ b/SpecViaZ/ZSigZAxioms.v
@@ -6,7 +6,7 @@
 (*         *       GNU Lesser General Public License Version 2.1        *)
 (************************************************************************)
 
-Require Import Bool ZArith OrdersFacts Nnat ZAxioms ZSig.
+Require Import Bool ZArith OrdersFacts Nnat ZAxioms ZSig Lia.
 
 (** * The interface [ZSig.ZType] implies the interface [ZAxiomsSig] *)
 
@@ -207,22 +207,22 @@ Qed.
 
 Theorem min_l : forall n m, n <= m -> min n m == n.
 Proof.
-intros n m. zify. omega with *.
+now intros n m; zify; lia.
 Qed.
 
 Theorem min_r : forall n m, m <= n -> min n m == m.
 Proof.
-intros n m. zify. omega with *.
+now intros n m; zify; lia.
 Qed.
 
 Theorem max_l : forall n m, m <= n -> max n m == n.
 Proof.
-intros n m. zify. omega with *.
+now intros n m; zify; lia.
 Qed.
 
 Theorem max_r : forall n m, n <= m -> max n m == m.
 Proof.
-intros n m. zify. omega with *.
+now intros n m; zify; lia.
 Qed.
 
 (** Part specific to integers, not natural numbers *)
@@ -250,27 +250,27 @@ Qed.
 
 Theorem abs_eq : forall n, 0 <= n -> abs n == n.
 Proof.
-intros n. zify. omega with *.
+now intros n; zify; lia.
 Qed.
 
 Theorem abs_neq : forall n, n <= 0 -> abs n == -n.
 Proof.
-intros n. zify. omega with *.
+now intros n; zify; lia.
 Qed.
 
 Theorem sgn_null : forall n, n==0 -> sgn n == 0.
 Proof.
-intros n. zify. omega with *.
+now intros n; zify; lia.
 Qed.
 
 Theorem sgn_pos : forall n, 0<n -> sgn n == 1.
 Proof.
-intros n. zify. omega with *.
+now intros n; zify; lia.
 Qed.
 
 Theorem sgn_neg : forall n, n<0 -> sgn n == opp 1.
 Proof.
-intros n. zify. omega with *.
+now intros n; zify; lia.
 Qed.
 
 (** Power *)

--- a/coq-bignums.opam
+++ b/coq-bignums.opam
@@ -18,7 +18,7 @@ install: [make "install"]
 
 depends: [
   "ocaml"
-  "coq" {= "dev"}
+  "coq" {(>= "8.11" & < "8.12~") | (= "dev")}
 ]
 
 tags: [

--- a/coq-bignums.opam
+++ b/coq-bignums.opam
@@ -13,12 +13,12 @@ Provides BigN, BigZ, BigQ that used to be part of Coq standard library
 
 version: "dev"
 
-build: ["dune" "build" "-p" name "-j" jobs]
+build: [make "-j%{jobs}%"]
+install: [make "install"]
 
 depends: [
   "ocaml"
   "coq" {= "dev"}
-  "dune" {>= "1.9.0"}
 ]
 
 tags: [

--- a/plugin/bignums_syntax.ml
+++ b/plugin/bignums_syntax.ml
@@ -14,7 +14,6 @@ let () = Mltop.add_known_module __coq_plugin_name
 
 open Bigint
 open Names
-open Globnames
 open Glob_term
 
 (*** Constants for locating bigN / bigZ / bigQ constructors ***)
@@ -44,7 +43,7 @@ let bigN_scope = "bigN_scope"
 let n_inlined = 7
 
 let bigN_constructor i =
-  ConstructRef ((bigN_t,0),(min i n_inlined)+1)
+  GlobRef.ConstructRef ((bigN_t,0),(min i n_inlined)+1)
 
 (*bigZ stuff*)
 let bigZ_module = ["Bignums"; "BigZ"; "BigZ" ]
@@ -52,8 +51,8 @@ let bigZ_path = make_path (bigZ_module@["BigZ"]) "t"
 let bigZ_t = make_mind_mpdot bigZ_module "BigZ" "t_"
 let bigZ_scope = "bigZ_scope"
 
-let bigZ_pos = ConstructRef ((bigZ_t,0),1)
-let bigZ_neg = ConstructRef ((bigZ_t,0),2)
+let bigZ_pos = GlobRef.ConstructRef ((bigZ_t,0),1)
+let bigZ_neg = GlobRef.ConstructRef ((bigZ_t,0),2)
 
 
 (*bigQ stuff*)
@@ -62,7 +61,7 @@ let bigQ_path = make_path (bigQ_module@["BigQ"]) "t"
 let bigQ_t = make_mind_mpdot bigQ_module "BigQ" "t_"
 let bigQ_scope = "bigQ_scope"
 
-let bigQ_z =  ConstructRef ((bigQ_t,0),1)
+let bigQ_z =  GlobRef.ConstructRef ((bigQ_t,0),1)
 
 
 let is_gr c r = match DAst.get c with


### PR DESCRIPTION
This PR integrate commits from `master` as well as specific commits for 8.11.

Namely: it ensures the v8.11 branch compiles with both Coq 8.11+beta1 and Coq dev (a CI test was missing for the former, and the latter build with dev was broken because the `master` commits were missing in this branch).

Also, it changes the build system to `coq_makefile` just in branch v8.11, for the upcoming release of coq-bignums to be on an equal footing with the packages Coq 8.11+beta1 (and Coq 8.11.0 opam to appear):
https://github.com/coq/opam-coq-archive/blob/master/core-dev/packages/coq/coq.8.11%2Bbeta1/opam#L37-L38

Cc @ppedrot @maximedenes @ejgallego FYI

@Zimmi48 do you have an idea why the Nix build fails? I tried with both `COQ=8.11` and `COQ=https://github.com/coq/coq-on-cachix/tarball/master` and got something like:

```
copying path '/nix/store/kmydvrryfqa1rir1v8n0am9vb3wp22yy-coq' from 'https://coq.cachix.org'...
bad archive: input doesn't look like a Nix archive
cannot build derivation '/nix/store/1y66b2wdnww7papk4sl9pwnk4ggpmwsq-bignums.drv': 1 dependencies couldn't be built
error: build of '/nix/store/1y66b2wdnww7papk4sl9pwnk4ggpmwsq-bignums.drv' failed
```