### PR TITLE
[build] [dune] Bump dune version

### DIFF
--- a/dune
+++ b/dune
@@ -2,5 +2,5 @@
 
 (coq.theory
  (name Bignums)
- (public_name coq-bignums)
+ (package coq-bignums)
  (libraries coq-bignums.plugin))

--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,3 @@
-(lang dune 1.9)
+(lang dune 2.3)
 (using coq 0.1)
 (name coq-bignums)


### PR DESCRIPTION
Dune 2.3 is recommended for packages. We may want to wait a bit to
merge this tho as not to force the upgrade path.