### PR TITLE
Compile native compute files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ Makefile.coq.conf
 *.install
 *.vos
 *.vok
+*.out.real

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ opam: &OPAM
       export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '
       set -ex  # -e = exit on failure; -x = trace for debug
       opam update -y
+      opam remove -y coq-bignums  # remove the coq-bignums from the docker image
       opam pin add ${CONTRIB_NAME} . -y -n -k path
       opam install ${CONTRIB_NAME} -y -j ${NJOBS} --deps-only
       opam config list
@@ -19,13 +20,20 @@ opam: &OPAM
       opam list
       "
   script:
-  - echo -e "${ANSI_YELLOW}Building ${CONTRIB_NAME}...${ANSI_RESET}" && echo -en 'travis_fold:start:script\\r'
+  - echo -e "${ANSI_YELLOW}Building and testing ${CONTRIB_NAME}...${ANSI_RESET}" && echo -en 'travis_fold:start:script\\r'
   - |
     docker exec COQ /bin/bash --login -c "
       export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '
       set -ex
       sudo chown -R coq:coq /home/coq/${CONTRIB_NAME}
       opam install ${CONTRIB_NAME} -v -y -j ${NJOBS}
+      "
+  - |
+    docker exec COQ /bin/bash --login -c "
+      export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '
+      set -ex
+      cd tests
+      make
       "
   - docker stop COQ  # optional
   - echo -en 'travis_fold:end:script\\r'

--- a/Makefile.coq.local
+++ b/Makefile.coq.local
@@ -1,0 +1,1 @@
+COQEXTRAFLAGS += -native-compiler yes

--- a/coq-bignums.opam
+++ b/coq-bignums.opam
@@ -13,12 +13,12 @@ Provides BigN, BigZ, BigQ that used to be part of Coq standard library
 
 version: "dev"
 
-build: ["dune" "build" "-p" name "-j" jobs]
+build: [make "-j%{jobs}%"]
+install: [make "install"]
 
 depends: [
   "ocaml"
   "coq" {= "dev"}
-  "dune" {>= "1.9.0"}
 ]
 
 tags: [

--- a/dune
+++ b/dune
@@ -3,5 +3,6 @@
 (coq.theory
  (name Bignums)
  (public_name coq-bignums)
+ (flags :standard -native-compiler yes)
  (libraries coq-bignums.plugin))
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,16 @@
+COQC=coqc -native-compiler yes
+
+all: success output
+
+success: $(addsuffix o,$(wildcard success/*.v))
+
+output: $(addsuffix o,$(wildcard output/*.v))
+
+success/%.vo: success/%.v
+	$(COQC) $<
+
+output/%.vo: output/%.v
+	input=$<; \
+	output=$${input%.v}.out.real; \
+	$(COQC) $< 2>&1 > $$output; \
+	diff --strip-trailing-cr $${input%.v}.out $$output

--- a/tests/output/NumbersSyntax.v
+++ b/tests/output/NumbersSyntax.v
@@ -1,5 +1,5 @@
-
-Require Import BigQ.
+Require Import ZArith.
+Require Import Bignums.BigQ.BigQ.
 
 Open Scope bigN_scope.
 Check 2.

--- a/tests/success/NumberScopes.v
+++ b/tests/success/NumberScopes.v
@@ -4,21 +4,21 @@
 
 Close Scope nat_scope.
 
-Require Import BigN.
+Require Import Bignums.BigN.BigN.
 Check (BigN.add 1 2).
 Check (BigN.add_comm 1 2).
 Check (BigN.min_comm 1 2).
 Definition f_bigN (x:bigN) := x.
 Check (f_bigN 1).
 
-Require Import BigZ.
+Require Import Bignums.BigZ.BigZ.
 Check (BigZ.add 1 2).
 Check (BigZ.add_comm 1 2).
 Check (BigZ.min_comm 1 2).
 Definition f_bigZ (x:bigZ) := x.
 Check (f_bigZ 1).
 
-Require Import BigQ.
+Require Import Bignums.BigQ.BigQ.
 Check (BigQ.add 1 2).
 Check (BigQ.add_comm 1 2).
 Check (BigQ.min_comm 1 2).

--- a/tests/success/bigQ.v
+++ b/tests/success/bigQ.v
@@ -1,4 +1,4 @@
-Require Import BigQ.
+Require Import Bignums.BigQ.BigQ.
 Import List.
 
 Definition pi_4_approx_low' := 


### PR DESCRIPTION
Following discussions with @ejgallego @erikmd and @maximedenes in #26 and coq/coq#11476 it appears that bignums should be compiled for native_compute by default. This PR offers just that.

It also takes the opportunity to ad a Makefile for the test subdirectory.

Moreover, this would act as a test that native_compute files of the standard library are indeed installed in the Coq CI.
