### PR TITLE
Disable native-compiler when not available

### DIFF
--- a/Makefile.coq.local
+++ b/Makefile.coq.local
@@ -1,1 +1,8 @@
-COQEXTRAFLAGS += -native-compiler yes
+ifneq (,$(COQBIN))
+# add an ending /
+COQBIN:=$(COQBIN)/
+endif
+COQC ?= "$(COQBIN)coqc"
+COQ_WITH_NATIVE_COMPILE := $(shell echo "Definition d := 0+1." > conftest.v && $(COQC) -native-compiler yes conftest.v 2> /dev/null && echo "yes" || echo "no")
+
+COQEXTRAFLAGS += -native-compiler $(COQ_WITH_NATIVE_COMPILE)


### PR DESCRIPTION
This is terribly hackish but it seems to work and I don't see any other solution.

Fixes #39 
