### PR TITLE
Adapt to coq/coq#13352

### DIFF
--- a/Makefile.coq.local
+++ b/Makefile.coq.local
@@ -1,2 +1,1 @@
 CAMLPKGS+=-package zarith
-COQEXTRAFLAGS += -native-compiler yes

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,4 +1,4 @@
-COQC=coqc -native-compiler yes
+COQC=coqc
 
 all: success output
 


### PR DESCRIPTION
Compilation with -native-compiler yes is no longer needed,
since native compilation is now decided at Coq's configure time.