### PR TITLE
compatibility with Coq PR #14045

### DIFF
--- a/BigN/NMake.v
+++ b/BigN/NMake.v
@@ -1451,19 +1451,19 @@ Module Make (W0:CyclicType) <: NType.
      rewrite <- HH; rewrite Z.mul_1_r.
      apply Z.pow_le_mono_r; auto with zarith. }
  rewrite (Z.mul_comm 2).
- rewrite Z.pow_mul_r; auto with zarith.
+ rewrite Z.pow_mul_r by auto with zarith.
  rewrite Z.pow_2_r.
  apply Z.lt_le_trans with (2 := HH3).
  rewrite <- Z.mul_assoc.
  replace (2 * Zpos (digits x) - 1) with
    ((Zpos (digits x) - 1) + (Zpos (digits x))).
- rewrite Zpower_exp; auto with zarith.
- apply Zmult_lt_compat2; auto with zarith.
- split; auto with zarith.
- apply Z.mul_pos_pos; auto with zarith.
- rewrite Pos2Z.inj_xO; ring.
- apply Z.lt_le_incl; auto.
- repeat rewrite spec_head00; auto.
+ rewrite Zpower_exp by auto with zarith.
+ apply Zmult_lt_compat2; [auto with zarith|].
+ -  split;[|auto with zarith].
+    apply Z.mul_pos_pos; auto with zarith.
+ -  rewrite Pos2Z.inj_xO; ring.
+ - apply Z.lt_le_incl; auto.
+ - repeat rewrite spec_head00; auto.
  rewrite spec_double_size_digits.
  rewrite Pos2Z.inj_xO; auto with zarith.
  rewrite spec_double_size; auto.

--- a/BigNumPrelude.v
+++ b/BigNumPrelude.v
@@ -263,8 +263,8 @@ Theorem Zmod_le_first: forall a b, 0 <= a -> 0 < b -> 0 <= a mod b <= a.
  apply Zdiv_lt_upper_bound; auto with zarith.
  apply Z.lt_le_trans with (2^n); auto with zarith.
  rewrite <- (Z.mul_1_r (2^n)) at 1.
+ assert (0 < 2^ (n-p)) by auto with zarith.
  apply Z.mul_le_mono_nonneg; auto with zarith.
- cut (0 < 2 ^ (n-p)); auto with zarith.
  Qed.
 
  Lemma div_le_0 : forall p x, 0 <= x -> 0 <= x / 2 ^ p.
@@ -281,8 +281,8 @@ Theorem Zmod_le_first: forall a b, 0 <= a -> 0 < b -> 0 <= a mod b <= a.
   intros p x y H;destruct (Z_le_gt_dec 0 p).
   apply Zdiv_lt_upper_bound;auto with zarith.
   apply Z.lt_le_trans with y;auto with zarith.
+  assert (0 < 2^p) by auto with zarith.
   rewrite <- (Z.mul_1_r y);apply Z.mul_le_mono_nonneg;auto with zarith.
-  assert (0 < 2^p);auto with zarith.
   replace (2^p) with 0.
   destruct x;change (0<y);auto with zarith.
   destruct p;trivial;discriminate.

--- a/CyclicDouble/DoubleDivn1.v
+++ b/CyclicDouble/DoubleDivn1.v
@@ -391,12 +391,12 @@ Section GENDIVN1.
     rewrite spec_add_mul_div;auto with zarith.
     rewrite spec_0;rewrite Z.mul_0_l;rewrite Z.add_0_l.
     assert (([|high n a|]/2^(Zpos w_digits - [|w_head0 b|])) < wB).
-     apply Zdiv_lt_upper_bound;auto with zarith.
-     apply Z.lt_le_trans with wB;auto with zarith.
-     pattern wB at 1;replace wB with (wB*1);try ring.
-     apply Z.mul_le_mono_nonneg;auto with zarith.
-     assert (H6 := Z.pow_pos_nonneg 2 (Zpos w_digits - [|w_head0 b|]));
-       auto with zarith.
+    assert (H6 := Z.pow_pos_nonneg 2 (Zpos w_digits - [|w_head0 b|]));
+      auto with zarith.
+    apply Zdiv_lt_upper_bound;auto with zarith.
+    apply Z.lt_le_trans with wB;auto with zarith.
+    pattern wB at 1;replace wB with (wB*1);try ring.
+    apply Z.mul_le_mono_nonneg;auto with zarith.
     rewrite Zmod_small;auto with zarith.
     apply Zdiv_lt_upper_bound;auto with zarith.
     apply Z.lt_le_trans with wB;auto with zarith.

--- a/CyclicDouble/DoubleLift.v
+++ b/CyclicDouble/DoubleLift.v
@@ -197,9 +197,8 @@ Section DoubleLift.
        apply Z.lt_nge.
        case (spec_to_Z xl); intros HH3 HH4.
        apply Z.le_lt_trans with (2 := HH4).
-       apply Z.le_trans with (1 * 2 ^ [|w_tail0 xl|]); auto with zarith.
        rewrite Hz2.
-       apply Z.mul_le_mono_nonneg_r; auto with zarith.
+       apply Z.le_trans with (1 * 2 ^ [|w_tail0 xl|]); auto with zarith.
      apply Zpower_le_monotone; auto with zarith.
    exists ([|xh|] * (2 ^ ((Zpos w_digits - [|w_tail0 xl|]) - 1)) + z); split.
      apply Z.add_nonneg_nonneg; auto.


### PR DESCRIPTION
zify is more aggressive and generalises  the theorem
`0 < a -> 0 < b -> 0 < a ^ b.`

This PR repairs the few impacted proofs.
