### PR TITLE
Use Makefile.coq.local instead of `-extra`

### DIFF
--- a/Makefile.coq.local
+++ b/Makefile.coq.local
@@ -1,1 +1,7 @@
 CAMLPKGS+=-package zarith
+
+clean::
+	rm -f BigN/NMake_gen.v
+
+BigN/NMake_gen.v: BigN/gen/NMake_gen.ml
+	ocaml $< > $@ || (RV=$$?; rm -f $@; exit $${RV})

--- a/_CoqProject
+++ b/_CoqProject
@@ -27,5 +27,3 @@ BigZ/BigZ.v
 
 plugin/bignums_syntax.ml
 plugin/bignums_syntax_plugin.mlpack
-
--extra "BigN/NMake_gen.v" "BigN/gen/NMake_gen.ml" "ocaml $< > $@ || (RV=$$?; rm -f $@; exit $${RV})"


### PR DESCRIPTION
Build BigN/NMake_gen.v via Makefile.coq.local instead of using the deprecated `-extra` option of coq_makefile. This makes bignums compatible with the part of coq/coq#14558 which removes the `-extra`option.